### PR TITLE
Set up tox to run linters and tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+ignore =
+  E501  # line too long, defer to black
+  F401  # unused import, defer to pylint
+  W503  # allow line breaks before binary ops
+  W504  # allow line breaks after binary ops
+  E203  # allow whitespace before ':' (https://github.com/psf/black#slices) 
+exclude =
+  .git
+  .tox
+  CVS
+  .venv*/
+  venv*/
+  target
+  __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+.vscode/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,16 @@
+[settings]
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=79
+
+; 3 stands for Vertical Hanging Indent, e.g.
+; from third_party import (
+;     lib1,
+;     lib2,
+;     lib3,
+; )
+; docs: https://github.com/timothycrosley/isort#multi-line-output-modes
+multi_line_output=3
+skip=target
+skip_glob=**/gen/*,.venv*/*,venv*/*,**/proto/*,.tox

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,489 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,gen,proto
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=missing-docstring,
+      fixme, # Warns about FIXME, TODO, etc. comments.
+      too-few-public-methods, # Might be good to re-enable this later.
+      too-many-instance-attributes,
+      too-many-arguments,
+      ungrouped-imports, # Leave this up to isort
+      wrong-import-order, # Leave this up to isort
+      bad-continuation, # Leave this up to black
+      line-too-long, # Leave this up to black
+      exec-used
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+# enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+#evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=text
+
+# Tells whether to display a full report or only the messages.
+#reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+#ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+#ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+#ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_|^kwargs|^args
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=79
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=any
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=_,
+           log,
+           logger
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=yes
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+variable-rgx=(([a-z_][a-z0-9_]{1,})|(_[a-z0-9_]*)|(__[a-z][a-z0-9_]+__))$
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=yes
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=six
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -1,0 +1,5 @@
+pylint~=2.5.3
+flake8~=3.8.3
+isort~=4.3 # pinned for pylint
+black~=19.10b0
+mypy~=0.780

--- a/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -8,7 +8,6 @@ from google.api.metric_pb2 import MetricDescriptor
 from google.api.monitored_resource_pb2 import MonitoredResource
 from google.cloud.monitoring_v3 import MetricServiceClient
 from google.cloud.monitoring_v3.proto.metric_pb2 import TimeSeries
-
 from opentelemetry.sdk.metrics.export import (
     MetricRecord,
     MetricsExporter,

--- a/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -19,7 +19,6 @@ from google.api.label_pb2 import LabelDescriptor
 from google.api.metric_pb2 import MetricDescriptor
 from google.api.monitored_resource_pb2 import MonitoredResource
 from google.cloud.monitoring_v3.proto.metric_pb2 import TimeSeries
-
 from opentelemetry.exporter.cloud_monitoring import (
     MAX_BATCH_WRITE,
     UNIQUE_IDENTIFIER_KEY,

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -50,8 +50,7 @@ from google.cloud.trace_v2.proto.trace_pb2 import AttributeValue
 from google.cloud.trace_v2.proto.trace_pb2 import Span as ProtoSpan
 from google.cloud.trace_v2.proto.trace_pb2 import TruncatableString
 from google.rpc.status_pb2 import Status
-
-import opentelemetry.trace as trace_api
+from opentelemetry import trace as trace_api
 from opentelemetry.exporter.cloud_trace.version import (
     __version__ as cloud_trace_version,
 )

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/cloud_trace_propagator.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/cloud_trace_propagator.py
@@ -16,7 +16,7 @@
 import re
 import typing
 
-import opentelemetry.trace as trace
+from opentelemetry import trace
 from opentelemetry.context.context import Context
 from opentelemetry.trace.propagation import httptextformat
 from opentelemetry.trace.span import (
@@ -27,6 +27,8 @@ from opentelemetry.trace.span import (
 
 _TRACE_CONTEXT_HEADER_NAME = "X-Cloud-Trace-Context"
 _TRACE_CONTEXT_HEADER_FORMAT = r"(?P<trace_id>[0-9a-f]{32})\/(?P<span_id>[\d]{1,20});o=(?P<trace_flags>\d+)"
+
+
 _TRACE_CONTEXT_HEADER_RE = re.compile(_TRACE_CONTEXT_HEADER_FORMAT)
 
 

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -1,5 +1,4 @@
 import requests
-
 from opentelemetry.context import attach, detach, set_value
 from opentelemetry.sdk.resources import Resource, ResourceDetector
 

--- a/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -20,7 +20,6 @@ from google.cloud.trace_v2.proto.trace_pb2 import AttributeValue
 from google.cloud.trace_v2.proto.trace_pb2 import Span as ProtoSpan
 from google.cloud.trace_v2.proto.trace_pb2 import TruncatableString
 from google.rpc.status_pb2 import Status
-
 from opentelemetry.exporter.cloud_trace import (
     MAX_EVENT_ATTRS,
     MAX_LINK_ATTRS,

--- a/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_propagator.py
+++ b/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_propagator.py
@@ -15,7 +15,7 @@
 import typing
 import unittest
 
-import opentelemetry.trace as trace
+from opentelemetry import trace
 from opentelemetry.context import get_current
 from opentelemetry.exporter.cloud_trace.cloud_trace_propagator import (
     _TRACE_CONTEXT_HEADER_NAME,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,84 @@
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist =
+  ; Add the `ci` factor to any env that should be running during CI.
+  py3{4,5,6,7,8}-ci-test-exporter-cloud-monitoring
+  py3{4,5,6,7,8}-ci-test-exporter-cloud-trace
+
+  ; These are development commands and use the same virtualenv.
+  dev
+  fix
+  lint
+
+  ; same as lint, but includes ci factor and uses clean virtualenv
+  lint-ci
+
+; this section contains constants that can be referenced elsewhere
+[constants]
+
+; The commit in opentelemetry-python repo that the code in this repository is
+; built against. Use this for pre-GA development, and eventually we will build
+; against releases and remove this. For now, bump this frequently with every PR
+; to develop as closely with that repo as possible while still tracking the
+; actual hash.
+opentelemetry_python_commit = 8cbd9d4db04f0cd0b5a32c8c8c80299b4a44f9bd
+opentelemetry_api_dep =
+  git+https://github.com/open-telemetry/opentelemetry-python.git@{[constants]opentelemetry_python_commit}#egg=opentelemetry-api&subdirectory=opentelemetry-api
+opentelemetry_sdk_dep =
+  git+https://github.com/open-telemetry/opentelemetry-python.git@{[constants]opentelemetry_python_commit}#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
+
+base_deps =
+  -c dev-constraints.txt
+  {[constants]opentelemetry_api_dep}
+  {[constants]opentelemetry_sdk_dep}
+
+dev_basepython = python3.8
+dev_deps =
+  {[constants]base_deps}
+  black
+  flake8
+  isort
+  pylint
+  -e {toxinidir}/opentelemetry-exporter-cloud-monitoring
+  -e {toxinidir}/opentelemetry-exporter-cloud-trace
+
+lint_commands =
+  black . --diff --check
+  isort --recursive . --diff --check-only
+  flake8 .
+  bash -c "pylint $(find . -regex '\.\/opentelemetry\-.*\.pyi?$')"
+
+[testenv]
+deps =
+  {[constants]base_deps}
+  test: pytest
+
+changedir =
+  test-exporter-monitoring: opentelemetry-exporter-cloud-monitoring
+  test-exporter-trace: opentelemetry-exporter-cloud-trace
+
+commands_pre =
+  test: pip install .
+
+commands =
+  test: pytest
+
+whitelist_externals = bash
+
+; dev, lint, and env all use the same virtualenv. To (re)create the virtualenv
+; for development, run `tox -e dev`. To run fixers (black, isort) `tox -e fix`.
+; Lint is run as part of CI as well, so uses a separate.
+[testenv:{dev,fix,lint}]
+basepython = {[constants]dev_basepython}
+envdir = venv
+deps = {[constants]dev_deps}
+commands =
+  fix: black .
+  fix: isort --recursive .
+  lint: {[constants]lint_commands}
+
+[testenv:lint-ci]
+basepython = {[constants]dev_basepython}
+deps = {[constants]dev_deps}
+commands = {[constants]lint_commands}


### PR DESCRIPTION
Copied over `.flake8`, `.isort.cfg`, `.pylintrc`, and `pyproject.toml` (black config) from opentelemetry-python and removed any references to directories not in this new repo.

I added a `tox.ini` file similar to the one in opentelemetry-python, but I changed a few things up:
- Added a tox factor `ci` for any envs that should run during CI. That way you can quickly run `tox -f ci -pauto` to see what would run in CI
- Added a constant `opentelemetry_python_commit` which is the commit hash in opentelemetry-python repo that CI should run against.
  * For now, the opentelemetry-python repo is changing rapidly between releases, and development here is concurrent with that
  * CI won't flake as opentelemetry-python changes
  * If you go through commit history, you can see what is the corresponding commit in opentelemetry-python repo
  * Once we hit RC or GA, we will remove this and just build against releases.
- This tox setup handles creating a development virtualenv for you, just run `tox -e dev` and it will make `venv/` in the repo root. It is the same virtualenv used for `tox -e lint` and `tox -e fix`, which should avoid any weird mismatches between these (I noticed this a lot in opentelemetry-python repo eachdist script).