### PR TITLE
Added sphinx files and basic configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,13 @@ jobs:
           cache_key_base: lint-python3.8
           steps:
             - run: tox -e docs-ci
+      - run:
+          name: Upload docs html artifacts
+          command: |
+            cd docs/_build/html
+            zip -r docs.zip *
+      - store_artifacts:
+          path: docs/_build/html
 
   tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,10 @@ jobs:
           name: Upload docs html artifacts
           command: |
             cd docs/_build/html
-            zip -r docs.zip *
+            zip -r docs-html.zip *
       - store_artifacts:
           path: docs/_build/html
+          destination: docs-html
 
   tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,12 @@
 version: 2.1
 
+executors:
+  # Current version of python used in dev. Should match dev_basepython constant
+  # in tox.ini
+  dev_python:
+    docker:
+      - image: circleci/python:3.8
+
 commands:
   run_with_pip_cache:
     description: Run the passed steps with a restored pip cache
@@ -40,6 +47,7 @@ commands:
 
 jobs:
   lint:
+    executor: dev_python
     docker:
       - image: circleci/python:3.8
     steps:
@@ -48,6 +56,15 @@ jobs:
           cache_key_base: lint-python3.8
           steps:
             - run: tox -e lint-ci
+
+  docs:
+    executor: dev_python
+    steps:
+      - setup
+      - run_with_pip_cache:
+          cache_key_base: lint-python3.8
+          steps:
+            - run: tox -e docs-ci
 
   tests:
     parameters:
@@ -79,6 +96,7 @@ workflows:
   main:
     jobs:
       - lint
+      - docs
       - tests:
           name: tests-python3.<< matrix.python3_minor >>
           matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 cython_debug/
 
 .vscode/
+
+# Sphinx
+_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/cloud_monitoring/cloud_monitoring.rst
+++ b/docs/cloud_monitoring/cloud_monitoring.rst
@@ -1,0 +1,7 @@
+OpenTelemetry Cloud Monitoring Exporter
+=======================================
+
+.. automodule:: opentelemetry.exporter.cloud_monitoring
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/cloud_trace/cloud_trace.rst
+++ b/docs/cloud_trace/cloud_trace.rst
@@ -1,0 +1,7 @@
+OpenTelemetry Cloud Trace Exporter
+==================================
+
+.. automodule:: opentelemetry.exporter.cloud_trace
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,83 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "Google Cloud OpenTelemetry"
+copyright = "2020, Google"
+author = "Google"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    # API doc generation
+    "sphinx.ext.autodoc",
+    # Support for google-style docstrings
+    "sphinx.ext.napoleon",
+    # Infer types from hints instead of docstrings
+    "sphinx_autodoc_typehints",
+    # Add links to source from generated docs
+    "sphinx.ext.viewcode",
+    # Link to other sphinx docs
+    "sphinx.ext.intersphinx",
+    # Add a .nojekyll file to the generated HTML docs
+    # https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing
+    "sphinx.ext.githubpages",
+    # Support external links to different versions in the Github repo
+    "sphinx.ext.extlinks",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "opentelemetry": (
+        "https://opentelemetry-python.readthedocs.io/en/latest/",
+        None,
+    ),
+}
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "alabaster"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+html_theme_options = {
+    "github_repo": "opentelemetry-operations-python",
+    "github_user": "GoogleCloudPlatform",
+    "page_width": "1400px",
+    "sidebar_width": "320px",
+    "body_max_width": "800px",
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,37 @@
+.. Google Cloud OpenTelemetry documentation master file, created by
+   sphinx-quickstart on Fri Jul 17 19:47:46 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Google Cloud OpenTelemetry's documentation!
+======================================================
+
+This documentation describes OpenTelemetry Python exporters, propagators, and
+resource detectors for Google Cloud Platform. Development for these packages
+takes place on `Github
+<https://github.com/GoogleCloudPlatform/opentelemetry-operations-python>`_.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Exporters
+   :name: exporters
+
+   cloud_monitoring/cloud_monitoring
+   cloud_trace/cloud_trace
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Examples
+   :name: examples
+   :glob:
+
+   examples/**
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,12 @@ envlist =
 
   ; These are development commands and use the same virtualenv.
   dev
+  docs
   fix
   lint
 
-  ; same as lint, but includes ci factor and uses clean virtualenv
-  lint-ci
+  ; same as dev factors, but includes "ci" factor and uses clean virtualenv
+  {docs,lint}-ci
 
 ; this section contains constants that can be referenced elsewhere
 [constants]
@@ -43,11 +44,17 @@ dev_deps =
   -e {toxinidir}/opentelemetry-exporter-cloud-monitoring
   -e {toxinidir}/opentelemetry-exporter-cloud-trace
 
+docs_deps =
+  sphinx
+  sphinx-autodoc-typehints
+
 lint_commands =
   black . --diff --check
   isort --recursive . --diff --check-only
   flake8 .
   bash -c "pylint $(find . -regex '\.\/opentelemetry\-.*\.pyi?$')"
+
+docs_commands = make -C docs/ html
 
 [testenv]
 deps =
@@ -70,16 +77,34 @@ whitelist_externals = bash
 ; dev, lint, and env all use the same virtualenv. To (re)create the virtualenv
 ; for development, run `tox -e dev`. To run fixers (black, isort) `tox -e fix`.
 ; Lint is run as part of CI as well, so uses a separate.
-[testenv:{dev,fix,lint}]
+[testenv:{dev,fix,lint,docs}]
 basepython = {[constants]dev_basepython}
 envdir = venv
-deps = {[constants]dev_deps}
+
+deps =
+  {[constants]dev_deps}
+  {[constants]docs_deps}
+
 commands =
+  docs: make -C docs/ html
   fix: black .
   fix: isort --recursive .
   lint: {[constants]lint_commands}
 
-[testenv:lint-ci]
+whitelist_externals =
+  make
+  bash
+
+[testenv:{docs,lint}-ci]
 basepython = {[constants]dev_basepython}
-deps = {[constants]dev_deps}
-commands = {[constants]lint_commands}
+deps =
+  {[constants]dev_deps}
+  docs: {[constants]docs_deps}
+
+commands =
+  docs: {[constants]docs_commands}
+  lint: {[constants]lint_commands}
+
+whitelist_externals =
+  make
+  bash


### PR DESCRIPTION
Ran `sphinx-quickstart` and then added a few configuration options to the default theme. I also had to copy over `cloud_monitoring.rst` and `cloud_trace.rst` from the opentelemetry-python repo.

Added tox env to build the docs `tox -e docs` and a tox ci env to build docs in ci. Updated CircleCI to run it.

Next, I will set up readthedocs.io to build these.

Closes #27.