### PR TITLE
Add support for ValueObserver

### DIFF
--- a/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -247,10 +247,8 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
                     NANOS_PER_SECOND,
                 )
         else:
-            (
-                point.interval.start_time.seconds,
-                point.interval.start_time.nanos,
-            ) = (seconds, nanos)
+            point.interval.start_time.seconds = seconds
+            point.interval.start_time.nanos = nanos
 
         self._last_updated[
             updated_key

--- a/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -399,16 +399,16 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             [MetricRecord(MockMetric(meter=MockMeter()), (), aggregator,)]
         )
 
-        series1 = TimeSeries()
-        series1.metric.type = "custom.googleapis.com/OpenTelemetry/name"
-        point = series1.points.add()
+        series = TimeSeries()
+        series.metric.type = "custom.googleapis.com/OpenTelemetry/name"
+        point = series.points.add()
         point.value.int64_value = 5
         point.interval.end_time.seconds = WRITE_INTERVAL + 1
         point.interval.end_time.nanos = 0
         point.interval.start_time.seconds = WRITE_INTERVAL + 1
         point.interval.start_time.nanos = 0
         client.create_time_series.assert_has_calls(
-            [mock.call(self.project_name, [series1])]
+            [mock.call(self.project_name, [series])]
         )
 
     def test_stateless_times(self):

--- a/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -393,7 +393,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         )
 
         aggregator = ValueObserverAggregator()
-        aggregator.checkpoint = aggregator._TYPE(1, 1, 1, 1, 1)
+        aggregator.checkpoint = aggregator._TYPE(1, 2, 3, 4, 5)
         aggregator.last_update_timestamp = (WRITE_INTERVAL + 1) * int(1e9)
         exporter.export(
             [MetricRecord(MockMetric(meter=MockMeter()), (), aggregator,)]
@@ -402,7 +402,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         series1 = TimeSeries()
         series1.metric.type = "custom.googleapis.com/OpenTelemetry/name"
         point = series1.points.add()
-        point.value.int64_value = 1
+        point.value.int64_value = 5
         point.interval.end_time.seconds = WRITE_INTERVAL + 1
         point.interval.end_time.nanos = 0
         point.interval.start_time.seconds = WRITE_INTERVAL + 1


### PR DESCRIPTION
The aggregation method that ValueObserver uses, ValueObserverAggregator was previously unsupported. After offline discussion with @aabmass and @cnnradams we agreed on a method of representing this info in Cloud Monitoring.

Resolves https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/18