### PR TITLE
Add config for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  image: latest
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs-requirements.txt

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -1,5 +1,14 @@
-pylint~=2.5.3
+black~=19.10b0
 flake8~=3.8.3
 isort~=4.3 # pinned for pylint
-black~=19.10b0
 mypy~=0.780
+pylint~=2.5.3
+Sphinx==3.1.2
+
+# TODO: #19
+# Require opentelemetry-api/sdk packages from a specific git commit for close
+# development before GA. After GA, we will build against specific releases.
+# Bump the commit frequently during development whenever you are missing
+# changes from upstream.
+-e git+https://github.com/open-telemetry/opentelemetry-python.git@545068d6eb61beaab031af45b1572d70e6652bc3#egg=opentelemetry-api&subdirectory=opentelemetry-api
+-e git+https://github.com/open-telemetry/opentelemetry-python.git@545068d6eb61beaab031af45b1572d70e6652bc3#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,7 @@
+-c dev-constraints.txt
+Sphinx
+sphinx-autodoc-typehints
+opentelemetry-api
+opentelemetry-sdk
+./opentelemetry-exporter-cloud-monitoring/
+./opentelemetry-exporter-cloud-trace/

--- a/tox.ini
+++ b/tox.ini
@@ -18,21 +18,10 @@ envlist =
 ; this section contains constants that can be referenced elsewhere
 [constants]
 
-; The commit in opentelemetry-python repo that the code in this repository is
-; built against. Use this for pre-GA development, and eventually we will build
-; against releases and remove this. For now, bump this frequently with every PR
-; to develop as closely with that repo as possible while still tracking the
-; actual hash.
-opentelemetry_python_commit = 545068d6eb61beaab031af45b1572d70e6652bc3
-opentelemetry_api_dep =
-  git+https://github.com/open-telemetry/opentelemetry-python.git@{[constants]opentelemetry_python_commit}#egg=opentelemetry-api&subdirectory=opentelemetry-api
-opentelemetry_sdk_dep =
-  git+https://github.com/open-telemetry/opentelemetry-python.git@{[constants]opentelemetry_python_commit}#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
-
 base_deps =
   -c dev-constraints.txt
-  {[constants]opentelemetry_api_dep}
-  {[constants]opentelemetry_sdk_dep}
+  opentelemetry-api
+  opentelemetry-sdk
 
 dev_basepython = python3.8
 dev_deps =
@@ -44,19 +33,19 @@ dev_deps =
   -e {toxinidir}/opentelemetry-exporter-cloud-monitoring
   -e {toxinidir}/opentelemetry-exporter-cloud-trace
 
-docs_deps =
-  sphinx
-  sphinx-autodoc-typehints
-
 lint_commands =
   black . --diff --check
   isort --recursive . --diff --check-only
   flake8 .
   bash -c "pylint $(find . -regex '\.\/opentelemetry\-.*\.pyi?$')"
 
+docs_deps =
+  -r docs-requirements.txt
 docs_commands = make -C docs/ html
 
+
 [testenv]
+download = true
 deps =
   {[constants]base_deps}
   test: pytest

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ lint_commands =
 
 docs_deps =
   -r docs-requirements.txt
-docs_commands = make -C docs/ html
+docs_commands = make -C docs/ clean html
 
 
 [testenv]
@@ -75,7 +75,7 @@ deps =
   {[constants]docs_deps}
 
 commands =
-  docs: make -C docs/ html
+  docs: {[constants]docs_commands}
   fix: black .
   fix: isort --recursive .
   lint: {[constants]lint_commands}


### PR DESCRIPTION
Added `.readthedocs.yml` config to build sphinx docs, and also added a webhook for them to update on pushes and PRs. You can see the builds/docs, including those for PRs, here: https://readthedocs.org/projects/google-cloud-opentelemetry/builds/. Here is the built docs for this PR: https://google-cloud-opentelemetry--34.org.readthedocs.build/en/34/

Unfortunately I can't set up the PR status check which would add a link to each PR because without giving ReadTheDocs access to the GoogleCloudPlatform github org.

Last thing to note, I had to move the opentelemetry-python commit hash to `dev-constraints.txt` because ReadTheDocs won't let you specify a build command, you have to give it the dependencies and this was the easiest reusable way to do that. Unfortunately, because tox can't detect changes to external files like that, you may need to run `tox -r ...` to recreate virtualenvs when they becomes stale 😢 
