### PR TITLE
Add integration tests for trace using mock server

### DIFF
--- a/get_mock_server.sh
+++ b/get_mock_server.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if ! [ -e $1/mock_server-x64-linux ]; then
+  curl -L -o $1/mock_server-x64-linux https://github.com/googleinterns/cloud-operations-api-mock/raw/master/cmd/mock_server-x64-linux
+  chmod +x $1/mock_server-x64-linux
+fi
+

--- a/opentelemetry-exporter-cloud-trace/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-cloud-trace/tests/test_integration_cloud_trace_exporter.py
@@ -1,0 +1,88 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import subprocess
+import unittest
+from time import sleep
+
+import grpc
+from google.cloud.trace_v2 import TraceServiceClient
+from google.cloud.trace_v2.gapic.transports import trace_service_grpc_transport
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import Span, SpanExportResult
+from opentelemetry.trace import SpanContext, SpanKind
+
+
+class BaseExporterIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        # Find a free port to spin up our server at.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("localhost", 0))
+        self.address = "localhost:" + str(sock.getsockname()[1])
+        sock.close()
+
+        # Start the mock server.
+        args = "mock_server-x64-linux -address=" + self.address
+        self.mock_server_process = subprocess.Popen(args, shell=True)
+
+    def tearDown(self):
+        self.mock_server_process.kill()
+
+
+class TestCloudTraceSpanExporter(BaseExporterIntegrationTest):
+    def test_export(self):
+        project_id = "TEST-PROJECT"
+        trace_id = "6e0c63257de34c92bf9efcd03927272e"
+        span_id = "95bb5edabd45950f"
+
+        # Create span and associated data.
+        resource_info = Resource(
+            {
+                "cloud.account.id": 123,
+                "host.id": "host",
+                "cloud.zone": "US",
+                "cloud.provider": "gcp",
+                "gcp.resource_type": "gce_instance",
+            }
+        )
+        span = Span(
+            name="span_name",
+            context=SpanContext(
+                trace_id=int(trace_id, 16),
+                span_id=int(span_id, 16),
+                is_remote=False,
+            ),
+            parent=None,
+            kind=SpanKind.INTERNAL,
+            resource=resource_info,
+            attributes={"attr_key": "attr_value"},
+        )
+        span.start()
+        sleep(0.1)
+        span.end()
+        span_data = [span]
+
+        # Setup the exporter.
+        channel = grpc.insecure_channel(self.address)
+        transport = trace_service_grpc_transport.TraceServiceGrpcTransport(
+            channel=channel
+        )
+        client = TraceServiceClient(transport=transport)
+        exporter = CloudTraceSpanExporter(project_id, client=client)
+
+        # Export the spans and verify the results.
+        result = exporter.export(span_data)
+        self.assertEqual(result, SpanExportResult.SUCCESS)

--- a/opentelemetry-exporter-cloud-trace/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-cloud-trace/tests/test_integration_cloud_trace_exporter.py
@@ -15,7 +15,6 @@
 import socket
 import subprocess
 import unittest
-from time import sleep
 
 import grpc
 from google.cloud.trace_v2 import TraceServiceClient
@@ -24,10 +23,13 @@ from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import Span, SpanExportResult
 from opentelemetry.trace import SpanContext, SpanKind
+from opentelemetry.util import time_ns
 
 
 class BaseExporterIntegrationTest(unittest.TestCase):
     def setUp(self):
+        self.project_id = "TEST-PROJECT"
+
         # Find a free port to spin up our server at.
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(("localhost", 0))
@@ -35,8 +37,12 @@ class BaseExporterIntegrationTest(unittest.TestCase):
         sock.close()
 
         # Start the mock server.
-        args = "mock_server-x64-linux -address=" + self.address
-        self.mock_server_process = subprocess.Popen(args, shell=True)
+        args = ["mock_server-x64-linux", "-address", self.address]
+        self.mock_server_process = subprocess.Popen(
+            args, stderr=subprocess.PIPE
+        )
+        # Block until the mock server starts (it will output the address after starting).
+        self.mock_server_process.stderr.readline()
 
     def tearDown(self):
         self.mock_server_process.kill()
@@ -44,7 +50,6 @@ class BaseExporterIntegrationTest(unittest.TestCase):
 
 class TestCloudTraceSpanExporter(BaseExporterIntegrationTest):
     def test_export(self):
-        project_id = "TEST-PROJECT"
         trace_id = "6e0c63257de34c92bf9efcd03927272e"
         span_id = "95bb5edabd45950f"
 
@@ -70,19 +75,20 @@ class TestCloudTraceSpanExporter(BaseExporterIntegrationTest):
             resource=resource_info,
             attributes={"attr_key": "attr_value"},
         )
-        span.start()
-        sleep(0.1)
-        span.end()
+
+        # pylint: disable=protected-access
+        span._start_time = int(time_ns() - (60 * 1e9))
+        span._end_time = time_ns()
         span_data = [span]
 
-        # Setup the exporter.
+        # Setup the trace exporter.
         channel = grpc.insecure_channel(self.address)
         transport = trace_service_grpc_transport.TraceServiceGrpcTransport(
             channel=channel
         )
         client = TraceServiceClient(transport=transport)
-        exporter = CloudTraceSpanExporter(project_id, client=client)
+        trace_exporter = CloudTraceSpanExporter(self.project_id, client=client)
 
         # Export the spans and verify the results.
-        result = exporter.export(span_data)
+        result = trace_exporter.export(span_data)
         self.assertEqual(result, SpanExportResult.SUCCESS)

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,8 @@ changedir =
 
 commands_pre =
   test: pip install .
+  test: bash -c '[[ -e {envbindir}/mock_server-x64-linux ]] || curl -L -o {envbindir}/mock_server-x64-linux https://github.com/googleinterns/cloud-operations-api-mock/raw/master/cmd/mock_server-x64-linux'
+  test: bash -c 'chmod +x {envbindir}/mock_server-x64-linux'
 
 commands =
   ; use subshell to allow using tox envars in substitution

--- a/tox.ini
+++ b/tox.ini
@@ -67,8 +67,7 @@ changedir =
 
 commands_pre =
   test: pip install .
-  test: bash -c '[[ -e {envbindir}/mock_server-x64-linux ]] || curl -L -o {envbindir}/mock_server-x64-linux https://github.com/googleinterns/cloud-operations-api-mock/raw/master/cmd/mock_server-x64-linux'
-  test: bash -c 'chmod +x {envbindir}/mock_server-x64-linux'
+  test: {toxinidir}/get_mock_server.sh {envbindir}
 
 commands =
   ; use subshell to allow using tox envars in substitution


### PR DESCRIPTION
We'd like to integrate [our mock server](https://docs.google.com/document/d/1ZUwuqKIcTjrR32oxKwJw8XFNThQ8qDm_KvmTzzgiwtQ/edit#heading=h.h76dy5b7dqq2) into the Python exporter to be used for integration testing.

To setup the server, Tox will curl the binaries from [our repository](https://github.com/googleinterns/cloud-operations-api-mock). Then, the tests themselves will spin up the server, run the integration tests, and teardown the server.

Currently, the integration test just calls the mock server with the translated spans to verify that they follow the correct format and that the exporter has translated the spans properly. In the future, more tests can be added as needed