### PR TITLE
Docs updates with automatic API docs, pypi links, and contributing.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ cython_debug/
 
 # Sphinx
 _build/
+_autosummary/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Open-Telemetry Operations Exporters for Python
 
-Provides OpenTelemetry Exporters for Google Cloud Operations. 
+[![Documentation Status](https://readthedocs.org/projects/google-cloud-opentelemetry/badge/?version=latest)](https://google-cloud-opentelemetry.readthedocs.io/en/latest/?badge=latest)
+
+Provides OpenTelemetry Python exporters, propagators, and resource detectors
+for Google Cloud Platform.
+
+## Documentation
+
+Docs are available at <https://google-cloud-opentelemetry.readthedocs.io/en/latest/>
 
 ## Installation
 
+All packages are [available on PyPI](https://pypi.org/user/google_opentelemetry/) for installation with `pip`.
+
+## Contributing
+
+See the [contributing guide](docs/contributing.md).

--- a/docs/_templates/custom-class-template.rst
+++ b/docs/_templates/custom-class-template.rst
@@ -1,0 +1,34 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__, __add__, __mul__
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in methods %}
+      {%- if not item.startswith('_') %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/_templates/custom-module-template.rst
+++ b/docs/_templates/custom-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Module attributes
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+      :nosignatures:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -1,0 +1,25 @@
+API Reference
+=============
+
+..
+   The above .. prevents the autosummary table from rendering in the
+   document, but still causes the recursive generation of autodoc stub files.
+
+   .. autosummary::
+      :toctree: _autosummary
+      :caption: API Reference
+      :template: custom-module-template.rst
+      :recursive:
+
+      opentelemetry.exporter
+      opentelemetry.tools
+
+
+
+.. toctree::
+   :maxdepth: 5
+   :caption: API Reference
+   :name: apireference
+
+   _autosummary/opentelemetry.exporter
+   _autosummary/opentelemetry.tools

--- a/docs/cloud_monitoring/cloud_monitoring.rst
+++ b/docs/cloud_monitoring/cloud_monitoring.rst
@@ -1,7 +1,11 @@
 OpenTelemetry Cloud Monitoring Exporter
 =======================================
 
+.. image:: https://badge.fury.io/py/opentelemetry-exporter-cloud-monitoring.svg
+    :target: https://badge.fury.io/py/opentelemetry-exporter-cloud-monitoring
+
 .. automodule:: opentelemetry.exporter.cloud_monitoring
     :members:
     :undoc-members:
     :show-inheritance:
+    :noindex:

--- a/docs/cloud_trace/cloud_trace.rst
+++ b/docs/cloud_trace/cloud_trace.rst
@@ -1,7 +1,11 @@
 OpenTelemetry Cloud Trace Exporter
 ==================================
 
+.. image:: https://badge.fury.io/py/opentelemetry-exporter-cloud-trace.svg
+    :target: https://badge.fury.io/py/opentelemetry-exporter-cloud-trace
+
 .. automodule:: opentelemetry.exporter.cloud_trace
     :members:
     :undoc-members:
     :show-inheritance:
+    :noindex:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ author = "Google"
 extensions = [
     # API doc generation
     "sphinx.ext.autodoc",
+    # Automatically generate autodoc API docs
+    "sphinx.ext.autosummary",
     # Support for google-style docstrings
     "sphinx.ext.napoleon",
     # Infer types from hints instead of docstrings
@@ -52,6 +54,8 @@ intersphinx_mapping = {
         None,
     ),
 }
+
+autosummary_generate = True  # automatically generate autodoc stubs
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,64 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
+It is a good idea to create your pull request as a
+[Draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
+Once you have looked over your pull request and all CI checks are passing,
+publish your changes.
+
 ## Community Guidelines
 
 This project follows [Google's Open Source Community
 Guidelines](https://opensource.google/conduct/).
+
+## Development Instructions
+
+### Install tox
+
+This project uses [tox](https://tox.readthedocs.io/en/latest/index.html) for
+development, so make sure it is installed on your system:
+
+```sh
+pip install tox tox-factor
+```
+
+To create the virtual environment `venv/` in the project root for
+development, run:
+
+```sh
+tox -e dev
+```
+
+### Running tests
+
+This project supports python versions 3.4 to 3.8. To run tests, use `tox`:
+
+```sh
+# List all tox environments
+tox -l
+
+# Run python3.8 cloud trace tests
+tox -e py38-ci-test-exporter-cloud-trace
+
+# Run all python3.8 unit tests in parallel
+tox -f py38-test -pauto
+
+# All checks that run in continuous integration use the "ci" factor, which
+# makes it easy to test without submitting a PR. To run all of them in
+# parallel, skipping any python versions that are not present on your system:
+tox -s true -f ci -pauto
+```
+
+### Running lint and autofix
+
+```sh
+# Run lint checks
+tox -e lint
+
+# To fix formatting and import ordering lint issues automatically
+tox -e fix
+```
+
+### Issues
+
+`tox` usually recreates virtual environments for you whenever the config changes. However, it doesn't fully track external requirements files and your dependencies can be outdated. Either delete the `.tox/` directory or use the `-r` flag with tox to recreate virtual environments.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,15 @@ takes place on `Github
    examples/**
 
 
+.. toctree::
+   :hidden:
+
+   apireference
+
+:ref:`apireference`
+
+
+
 Indices and tables
 ==================
 

--- a/opentelemetry-exporter-cloud-monitoring/README.rst
+++ b/opentelemetry-exporter-cloud-monitoring/README.rst
@@ -1,6 +1,9 @@
 OpenTelemetry Cloud Monitoring Exporters
 ========================================
 
+.. image:: https://badge.fury.io/py/opentelemetry-exporter-cloud-monitoring.svg
+    :target: https://badge.fury.io/py/opentelemetry-exporter-cloud-monitoring
+
 This library provides classes for exporting metrics data to Google Cloud Monitoring.
 
 Installation

--- a/opentelemetry-exporter-cloud-trace/README.rst
+++ b/opentelemetry-exporter-cloud-trace/README.rst
@@ -1,6 +1,9 @@
 OpenTelemetry Cloud Trace Exporters
 ===================================
 
+.. image:: https://badge.fury.io/py/opentelemetry-exporter-cloud-trace.svg
+    :target: https://badge.fury.io/py/opentelemetry-exporter-cloud-trace
+
 This library provides classes for exporting trace data to Google Cloud Trace.
 
 Installation


### PR DESCRIPTION
Check out the built docs to see all of these changes here: https://google-cloud-opentelemetry--39.org.readthedocs.build/en/39/

- Use [Sphinx autosummary](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html) to recursively create stub files with `..autodoc` directives.
  * Mostly did this following [these instructions](https://stackoverflow.com/questions/2701998/sphinx-autodoc-is-not-automatic-enough/62613202#62613202). This is where `custom-module-templates.rst` and `custom-class-template.rst` come from.
  * This causes all of the python code to be indexed and added to the [Module Index](https://google-cloud-opentelemetry--39.org.readthedocs.build/en/39/py-modindex.html) sphinx creates.
  * I also added an [API Reference](https://google-cloud-opentelemetry--39.org.readthedocs.build/en/39/apireference.html#apireference) section that shows the docs as a tree. You also get hierarchical TOC links in the sidebar.
- Added PyPI badges in the `README.rst` files as well as in the actual documentation rst files.
- Added ReadTheDocs badges and links to `README.md`
- Updated `contributing.md` with development instructions.