### PR TITLE
bump ot commit to open-telemetry/opentelemetry-python@8bc7786b191b4f1b1f161de983db71643bf9f51e

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -10,5 +10,5 @@ Sphinx==3.1.2
 # development before GA. After GA, we will build against specific releases.
 # Bump the commit frequently during development whenever you are missing
 # changes from upstream.
--e git+https://github.com/open-telemetry/opentelemetry-python.git@545068d6eb61beaab031af45b1572d70e6652bc3#egg=opentelemetry-api&subdirectory=opentelemetry-api
--e git+https://github.com/open-telemetry/opentelemetry-python.git@545068d6eb61beaab031af45b1572d70e6652bc3#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk
+-e git+https://github.com/open-telemetry/opentelemetry-python.git@8bc7786b191b4f1b1f161de983db71643bf9f51e#egg=opentelemetry-api&subdirectory=opentelemetry-api
+-e git+https://github.com/open-telemetry/opentelemetry-python.git@8bc7786b191b4f1b1f161de983db71643bf9f51e#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk


### PR DESCRIPTION
Opentelemetry python are doing a release later today. Want to bump our version in preparation and make sure all tests are passing at open-telemetry/opentelemetry-python@8bc7786b191b4f1b1f161de983db71643bf9f51e