### PR TITLE
dont deepcopy resource labels multiple times

### DIFF
--- a/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -99,16 +99,16 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
         Args:
             series: ProtoBuf TimeSeries
         """
-
-        if resource.labels.get("cloud.provider") != "gcp":
+        resource_labels = resource.labels
+        if resource_labels.get("cloud.provider") != "gcp":
             return None
-        resource_type = resource.labels["gcp.resource_type"]
+        resource_type = resource_labels["gcp.resource_type"]
         if resource_type not in OT_RESOURCE_LABEL_TO_GCP:
             return None
         return MonitoredResource(
             type=resource_type,
             labels={
-                gcp_label: str(resource.labels[ot_label])
+                gcp_label: str(resource_labels[ot_label])
                 for ot_label, gcp_label in OT_RESOURCE_LABEL_TO_GCP[
                     resource_type
                 ].items()

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -318,14 +318,15 @@ OT_RESOURCE_LABEL_TO_GCP = {
 
 
 def _extract_resources(resource: Resource) -> Dict[str, str]:
-    if resource.labels.get("cloud.provider") != "gcp":
+    resource_labels = resource.labels
+    if resource_labels.get("cloud.provider") != "gcp":
         return {}
-    resource_type = resource.labels["gcp.resource_type"]
+    resource_type = resource_labels["gcp.resource_type"]
     if resource_type not in OT_RESOURCE_LABEL_TO_GCP:
         return {}
     return {
         "g.co/r/{}/{}".format(resource_type, gcp_resource_key,): str(
-            resource.labels[ot_resource_key]
+            resource_labels[ot_resource_key]
         )
         for ot_resource_key, gcp_resource_key in OT_RESOURCE_LABEL_TO_GCP[
             resource_type


### PR DESCRIPTION
Previously, every call to `resource.labels` would deepcopy all of the resource's labels due to the core implementation of Resources. We make this change to only deepcopy it once.