### PR TITLE
add support for list attribute values

### DIFF
--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -40,6 +40,7 @@ API
 ---
 """
 
+import collections
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -367,6 +368,7 @@ def _extract_attributes(
 
 
 def _format_attribute_value(value: types.AttributeValue) -> AttributeValue:
+
     if isinstance(value, bool):
         value_type = "bool_value"
     elif isinstance(value, int):
@@ -377,10 +379,15 @@ def _format_attribute_value(value: types.AttributeValue) -> AttributeValue:
     elif isinstance(value, float):
         value_type = "string_value"
         value = _get_truncatable_str_object("{:0.4f}".format(value), 256)
+    elif isinstance(value, collections.Sequence):
+        value_type = "string_value"
+        value = _get_truncatable_str_object(
+            "[" + ",".join([str(x) for x in value]) + "]", 256
+        )
     else:
         logger.warning(
             "ignoring attribute value %s of type %s. Values type must be one "
-            "of bool, int, string or float",
+            "of bool, int, string or float, or a sequence of these",
             value,
             type(value),
         )

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -368,7 +368,6 @@ def _extract_attributes(
 
 
 def _format_attribute_value(value: types.AttributeValue) -> AttributeValue:
-
     if isinstance(value, bool):
         value_type = "bool_value"
     elif isinstance(value, int):
@@ -382,7 +381,7 @@ def _format_attribute_value(value: types.AttributeValue) -> AttributeValue:
     elif isinstance(value, collections.Sequence):
         value_type = "string_value"
         value = _get_truncatable_str_object(
-            "[" + ",".join([str(x) for x in value]) + "]", 256
+            ",".join([str(x) for x in value]), 256
         )
     else:
         logger.warning(

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -381,7 +381,7 @@ def _format_attribute_value(value: types.AttributeValue) -> AttributeValue:
     elif isinstance(value, collections.Sequence):
         value_type = "string_value"
         value = _get_truncatable_str_object(
-            ",".join([str(x) for x in value]), 256
+            ",".join(str(x) for x in value), 256
         )
     else:
         logger.warning(

--- a/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -261,6 +261,40 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             ),
         )
 
+    def test_list_attribute_value(self):
+        self.assertEqual(
+            _format_attribute_value(("one", "two")),
+            AttributeValue(
+                string_value=TruncatableString(
+                    value="[one,two]", truncated_byte_count=0
+                )
+            ),
+        )
+        self.assertEqual(
+            _format_attribute_value([True]),
+            AttributeValue(
+                string_value=TruncatableString(
+                    value="[True]", truncated_byte_count=0
+                )
+            ),
+        )
+        self.assertEqual(
+            _format_attribute_value((2, 5)),
+            AttributeValue(
+                string_value=TruncatableString(
+                    value="[2,5]", truncated_byte_count=0
+                )
+            ),
+        )
+        self.assertEqual(
+            _format_attribute_value([2.0, 0.5, 4.55]),
+            AttributeValue(
+                string_value=TruncatableString(
+                    value="[2.0,0.5,4.55]", truncated_byte_count=0
+                )
+            ),
+        )
+
     def test_attribute_key_truncation(self):
         self.assertEqual(
             _extract_attributes(

--- a/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -266,7 +266,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             _format_attribute_value(("one", "two")),
             AttributeValue(
                 string_value=TruncatableString(
-                    value="[one,two]", truncated_byte_count=0
+                    value="one,two", truncated_byte_count=0
                 )
             ),
         )
@@ -274,7 +274,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             _format_attribute_value([True]),
             AttributeValue(
                 string_value=TruncatableString(
-                    value="[True]", truncated_byte_count=0
+                    value="True", truncated_byte_count=0
                 )
             ),
         )
@@ -282,7 +282,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             _format_attribute_value((2, 5)),
             AttributeValue(
                 string_value=TruncatableString(
-                    value="[2,5]", truncated_byte_count=0
+                    value="2,5", truncated_byte_count=0
                 )
             ),
         )
@@ -290,7 +290,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             _format_attribute_value([2.0, 0.5, 4.55]),
             AttributeValue(
                 string_value=TruncatableString(
-                    value="[2.0,0.5,4.55]", truncated_byte_count=0
+                    value="2.0,0.5,4.55", truncated_byte_count=0
                 )
             ),
         )


### PR DESCRIPTION
OT attribute values support having a sequence of primitives (list of ints, tuple of floats, etc). Cloud Trace does NOT support having a list of things as an attribute value, so we would ignore these values. This PR makes it so, instead of ignoring these, we convert them to a string and send it off as usual.