### PR TITLE
Add spankind support

### DIFF
--- a/opentelemetry-exporter-google-cloud/setup.cfg
+++ b/opentelemetry-exporter-google-cloud/setup.cfg
@@ -27,7 +27,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     google-cloud-monitoring
-    google-cloud-trace
+    google-cloud-trace >= 0.24.0
     opentelemetry-api
     opentelemetry-sdk
 

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -298,18 +298,20 @@ def _extract_events(events: Sequence[Event]) -> ProtoSpan.TimeEvents:
 
 
 # pylint: disable=no-member
+SPAN_KIND_MAPPING = {
+    trace_api.SpanKind.INTERNAL: ProtoSpan.SpanKind.INTERNAL,
+    trace_api.SpanKind.CLIENT: ProtoSpan.SpanKind.CLIENT,
+    trace_api.SpanKind.SERVER: ProtoSpan.SpanKind.SERVER,
+    trace_api.SpanKind.PRODUCER: ProtoSpan.SpanKind.PRODUCER,
+    trace_api.SpanKind.CONSUMER: ProtoSpan.SpanKind.CONSUMER,
+}
+
+
+# pylint: disable=no-member
 def _extract_span_kind(span_kind: trace_api.SpanKind) -> ProtoSpan.SpanKind:
-    if span_kind == trace_api.SpanKind.INTERNAL:
-        return ProtoSpan.SpanKind.INTERNAL
-    if span_kind == trace_api.SpanKind.SERVER:
-        return ProtoSpan.SpanKind.SERVER
-    if span_kind == trace_api.SpanKind.CLIENT:
-        return ProtoSpan.SpanKind.CLIENT
-    if span_kind == trace_api.SpanKind.PRODUCER:
-        return ProtoSpan.SpanKind.PRODUCER
-    if span_kind == trace_api.SpanKind.CONSUMER:
-        return ProtoSpan.SpanKind.CONSUMER
-    return ProtoSpan.SpanKind.SPAN_KIND_UNSPECIFIED
+    return SPAN_KIND_MAPPING.get(
+        span_kind, ProtoSpan.SpanKind.SPAN_KIND_UNSPECIFIED
+    )
 
 
 def _strip_characters(ot_version):

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -168,6 +168,7 @@ class CloudTraceSpanExporter(SpanExporter):
                     "links": _extract_links(span.links),
                     "status": _extract_status(span.status),
                     "time_events": _extract_events(span.events),
+                    "span_kind": _extract_span_kind(span.kind),
                 }
             )
             # TODO: Leverage more of the Cloud Trace API, e.g.
@@ -294,6 +295,21 @@ def _extract_events(events: Sequence[Event]) -> ProtoSpan.TimeEvents:
         dropped_annotations_count=dropped_annontations,
         dropped_message_events_count=0,
     )
+
+
+# pylint: disable=no-member
+def _extract_span_kind(span_kind: trace_api.SpanKind) -> ProtoSpan.SpanKind:
+    if span_kind == trace_api.SpanKind.INTERNAL:
+        return ProtoSpan.SpanKind.INTERNAL
+    if span_kind == trace_api.SpanKind.SERVER:
+        return ProtoSpan.SpanKind.SERVER
+    if span_kind == trace_api.SpanKind.CLIENT:
+        return ProtoSpan.SpanKind.CLIENT
+    if span_kind == trace_api.SpanKind.PRODUCER:
+        return ProtoSpan.SpanKind.PRODUCER
+    if span_kind == trace_api.SpanKind.CONSUMER:
+        return ProtoSpan.SpanKind.CONSUMER
+    return ProtoSpan.SpanKind.SPAN_KIND_UNSPECIFIED
 
 
 def _strip_characters(ot_version):

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
@@ -30,6 +30,7 @@ from opentelemetry.exporter.cloud_trace import (
     _extract_events,
     _extract_links,
     _extract_resources,
+    _extract_span_kind,
     _extract_status,
     _format_attribute_value,
     _get_time_from_ns,
@@ -162,6 +163,8 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             "time_events": None,
             "start_time": None,
             "end_time": None,
+            # pylint: disable=no-member
+            "span_kind": ProtoSpan.SpanKind.INTERNAL,
         }
 
         client = mock.Mock()
@@ -630,3 +633,24 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
         self.assertEqual("3.1.0", _strip_characters("3.1.0beta"))
         self.assertEqual("4.2.0", _strip_characters("4b.2rc.0a"))
         self.assertEqual("6.20.15", _strip_characters("b6.20.15"))
+
+    # pylint: disable=no-member
+    def test_extract_span_kind(self):
+        self.assertEqual(
+            _extract_span_kind(SpanKind.INTERNAL), ProtoSpan.SpanKind.INTERNAL
+        )
+        self.assertEqual(
+            _extract_span_kind(SpanKind.CLIENT), ProtoSpan.SpanKind.CLIENT
+        )
+        self.assertEqual(
+            _extract_span_kind(SpanKind.SERVER), ProtoSpan.SpanKind.SERVER
+        )
+        self.assertEqual(
+            _extract_span_kind(SpanKind.CONSUMER), ProtoSpan.SpanKind.CONSUMER
+        )
+        self.assertEqual(
+            _extract_span_kind(SpanKind.PRODUCER), ProtoSpan.SpanKind.PRODUCER
+        )
+        self.assertEqual(
+            _extract_span_kind(-1), ProtoSpan.SpanKind.SPAN_KIND_UNSPECIFIED
+        )


### PR DESCRIPTION
google-cloud-trace has updated to [version 0.24.0](https://pypi.org/project/google-cloud-trace/) and now supports passing in SpanKind information. This PR updates the cloud trace exporter to send this SpanKind info out.