### PR TITLE
Share common test utils

### DIFF
--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 
-import socket
-import subprocess
-import unittest
-
 import grpc
 from google.cloud.monitoring_v3 import MetricServiceClient
 from google.cloud.monitoring_v3.gapic.transports import (
@@ -31,29 +27,7 @@ from opentelemetry.sdk import metrics
 from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
 
-
-# TODO: #46
-# Refactor duplicated code found in test_integration_cloud_trace_exporter.py
-class BaseExporterIntegrationTest(unittest.TestCase):
-    def setUp(self):
-        self.project_id = "TEST-PROJECT"
-
-        # Find a free port to spin up our server at.
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(("localhost", 0))
-        self.address = "localhost:" + str(sock.getsockname()[1])
-        sock.close()
-
-        # Start the mock server.
-        args = ["mock_server", "-address", self.address]
-        self.mock_server_process = subprocess.Popen(
-            args, stderr=subprocess.PIPE
-        )
-        # Block until the mock server starts (it will output the address after starting).
-        self.mock_server_process.stderr.readline()
-
-    def tearDown(self):
-        self.mock_server_process.kill()
+from test_common import BaseExporterIntegrationTest
 
 
 class TestCloudMonitoringSpanExporter(BaseExporterIntegrationTest):

--- a/opentelemetry-exporter-google-cloud/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_integration_cloud_trace_exporter.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import socket
-import subprocess
-import unittest
-
 import grpc
 from google.cloud.trace_v2 import TraceServiceClient
 from google.cloud.trace_v2.gapic.transports import trace_service_grpc_transport
@@ -25,27 +21,7 @@ from opentelemetry.sdk.trace.export import Span, SpanExportResult
 from opentelemetry.trace import SpanContext, SpanKind
 from opentelemetry.util import time_ns
 
-
-class BaseExporterIntegrationTest(unittest.TestCase):
-    def setUp(self):
-        self.project_id = "TEST-PROJECT"
-
-        # Find a free port to spin up our server at.
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(("localhost", 0))
-        self.address = "localhost:" + str(sock.getsockname()[1])
-        sock.close()
-
-        # Start the mock server.
-        args = ["mock_server", "-address", self.address]
-        self.mock_server_process = subprocess.Popen(
-            args, stderr=subprocess.PIPE
-        )
-        # Block until the mock server starts (it will output the address after starting).
-        self.mock_server_process.stderr.readline()
-
-    def tearDown(self):
-        self.mock_server_process.kill()
+from test_common import BaseExporterIntegrationTest
 
 
 class TestCloudTraceSpanExporter(BaseExporterIntegrationTest):

--- a/test-common/MANIFEST.in
+++ b/test-common/MANIFEST.in
@@ -1,0 +1,6 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include MANIFEST.in

--- a/test-common/setup.cfg
+++ b/test-common/setup.cfg
@@ -1,0 +1,13 @@
+[metadata]
+name = test-common
+description = Test utilities used across packages in the this repo
+
+[options]
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+
+[options.packages.find]
+where = src
+

--- a/test-common/setup.cfg
+++ b/test-common/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = test-common
-description = Test utilities used across packages in the this repo
+description = Test utilities used across packages in this repo
 
 [options]
 package_dir=

--- a/test-common/setup.py
+++ b/test-common/setup.py
@@ -1,0 +1,3 @@
+import setuptools
+
+setuptools.setup()

--- a/test-common/src/test_common/__init__.py
+++ b/test-common/src/test_common/__init__.py
@@ -1,0 +1,7 @@
+"""Test utilities used across packages
+
+This code is only used in other modules' tests
+"""
+
+
+from .base_exporter_integration_test import BaseExporterIntegrationTest

--- a/test-common/src/test_common/base_exporter_integration_test.py
+++ b/test-common/src/test_common/base_exporter_integration_test.py
@@ -1,0 +1,27 @@
+import socket
+import subprocess
+import unittest
+
+
+class BaseExporterIntegrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.project_id = "TEST-PROJECT"
+
+        # Find a free port to spin up our server at.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("localhost", 0))
+        self.address = "localhost:" + str(sock.getsockname()[1])
+        sock.close()
+
+        # Start the mock server.
+        args = ["mock_server", "-address", self.address]
+        self.mock_server_process = subprocess.Popen(
+            args, stderr=subprocess.PIPE
+        )
+        # Block until the mock server starts (it will output the address after starting).
+        if self.mock_server_process.stderr is None:
+            raise RuntimeError("stderr is None")
+        self.mock_server_process.stderr.readline()
+
+    def tearDown(self) -> None:
+        self.mock_server_process.kill()

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ base_deps =
   -c dev-constraints.txt
   opentelemetry-api
   opentelemetry-sdk
+  -e {toxinidir}/test-common
 
 dev_basepython = python3.8
 dev_deps =


### PR DESCRIPTION
Close #46 

Created a new package `test-common` (with `setup.py`) that is only used for an editable install in the test virtualenvs. It is not published to pypi.

The other option was to set `PYTHONPATH`, but I think this is a little clearer and also its what opentelemetry-python does.