### PR TITLE
fix breakages for opentelemetry v0.14b0

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -10,5 +10,5 @@ Sphinx==3.1.2
 # development before GA. After GA, we will build against specific releases.
 # Bump the commit frequently during development whenever you are missing
 # changes from upstream.
-opentelemetry-api~=0.13b0
-opentelemetry-sdk~=0.13b0
+opentelemetry-api~=0.14b0
+opentelemetry-sdk~=0.14b0

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -125,7 +125,7 @@ class CloudTraceSpanExporter(SpanExporter):
         cloud_trace_spans = []
 
         for span in spans:
-            ctx = span.get_context()
+            ctx = span.get_span_context()
             trace_id = get_hexadecimal_trace_id(ctx.trace_id)
             span_id = get_hexadecimal_span_id(ctx.span_id)
             span_name = "projects/{}/traces/{}/spans/{}".format(

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring.py
@@ -140,12 +140,20 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
 
         self.assertIsNone(
             exporter._get_metric_descriptor(
-                MetricRecord(MockMetric(), (), UnsupportedAggregator())
+                MetricRecord(
+                    MockMetric(),
+                    (),
+                    UnsupportedAggregator(),
+                    Resource.create_empty(),
+                )
             )
         )
 
         record = MetricRecord(
-            MockMetric(), (("label1", "value1"),), SumAggregator(),
+            MockMetric(),
+            (("label1", "value1"),),
+            SumAggregator(),
+            Resource.create_empty(),
         )
         metric_descriptor = exporter._get_metric_descriptor(record)
         client.create_metric_descriptor.assert_called_with(
@@ -181,6 +189,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     ("label4", False),
                 ),
                 SumAggregator(),
+                Resource.create_empty(),
             )
         )
         client.create_metric_descriptor.assert_called_with(
@@ -208,7 +217,12 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             project_id=self.project_id, client=client
         )
         exporter.project_name = self.project_name
-        record = MetricRecord(MockMetric(), (), ValueObserverAggregator(),)
+        record = MetricRecord(
+            MockMetric(),
+            (),
+            ValueObserverAggregator(),
+            Resource.create_empty(),
+        )
         exporter._get_metric_descriptor(record)
         client.create_metric_descriptor.assert_called_with(
             self.project_name,
@@ -244,6 +258,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (("label1", "value1"),),
                     UnsupportedAggregator(),
+                    Resource.create_empty(),
                 )
             ]
         )
@@ -287,11 +302,13 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(meter=MockMeter(resource=resource)),
                     (("label1", "value1"), ("label2", 1),),
                     sum_agg_one,
+                    Resource.create_empty(),
                 ),
                 MetricRecord(
                     MockMetric(meter=MockMeter(resource=resource)),
                     (("label1", "value2"), ("label2", 2),),
                     sum_agg_one,
+                    Resource.create_empty(),
                 ),
             ]
         )
@@ -340,11 +357,13 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (("label1", "value1"), ("label2", 1),),
                     sum_agg_two,
+                    Resource.create_empty(),
                 ),
                 MetricRecord(
                     MockMetric(),
                     (("label1", "value2"), ("label2", 2),),
                     sum_agg_two,
+                    Resource.create_empty(),
                 ),
             ]
         )
@@ -358,6 +377,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (("label1", "changed_label"), ("label2", 2),),
                     sum_agg_two,
+                    Resource.create_empty(),
                 ),
             ]
         )
@@ -410,7 +430,14 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             WRITE_INTERVAL + 1
         ) * NANOS_PER_SECOND
         exporter.export(
-            [MetricRecord(MockMetric(meter=MockMeter()), (), aggregator,)]
+            [
+                MetricRecord(
+                    MockMetric(meter=MockMeter()),
+                    (),
+                    aggregator,
+                    Resource.create_empty(),
+                )
+            ]
         )
 
         series = TimeSeries()
@@ -456,7 +483,14 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             WRITE_INTERVAL + 1
         ) * NANOS_PER_SECOND
         exporter.export(
-            [MetricRecord(MockMetric(meter=MockMeter()), (), aggregator,)]
+            [
+                MetricRecord(
+                    MockMetric(meter=MockMeter()),
+                    (),
+                    aggregator,
+                    Resource.create_empty(),
+                )
+            ]
         )
 
         series = TimeSeries()
@@ -511,7 +545,9 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         agg.checkpoint = 1
         agg.last_update_timestamp = (WRITE_INTERVAL + 1) * NANOS_PER_SECOND
 
-        metric_record = MetricRecord(MockMetric(stateful=False), (), agg)
+        metric_record = MetricRecord(
+            MockMetric(stateful=False), (), agg, Resource.create_empty()
+        )
 
         exporter.export([metric_record])
 
@@ -532,7 +568,9 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
 
         agg.last_update_timestamp = (WRITE_INTERVAL * 2 + 2) * NANOS_PER_SECOND
 
-        metric_record = MetricRecord(MockMetric(stateful=False), (), agg)
+        metric_record = MetricRecord(
+            MockMetric(stateful=False), (), agg, Resource.create_empty()
+        )
 
         exporter.export([metric_record])
 
@@ -585,7 +623,9 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
 
         sum_agg_one = SumAggregator()
         sum_agg_one.update(1)
-        metric_record = MetricRecord(MockMetric(), (), sum_agg_one,)
+        metric_record = MetricRecord(
+            MockMetric(), (), sum_agg_one, Resource.create_empty()
+        )
         exporter1.export([metric_record])
         exporter2.export([metric_record])
 

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
@@ -26,6 +26,7 @@ from opentelemetry.exporter.cloud_monitoring import (
 from opentelemetry.sdk import metrics
 from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
+from opentelemetry.sdk.resources import Resource
 
 from test_common import BaseExporterIntegrationTest
 
@@ -54,7 +55,14 @@ class TestCloudMonitoringSpanExporter(BaseExporterIntegrationTest):
         sum_agg.last_update_timestamp = (WRITE_INTERVAL + 2) * NANOS_PER_SECOND
 
         result = exporter.export(
-            [MetricRecord(counter, labels=(), aggregator=sum_agg,)]
+            [
+                MetricRecord(
+                    counter,
+                    labels=(),
+                    aggregator=sum_agg,
+                    resource=Resource.create_empty(),
+                )
+            ]
         )
 
         self.assertEqual(result, MetricsExportResult.SUCCESS)

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
@@ -42,7 +42,7 @@ from opentelemetry.exporter.google.version import (
 )
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event
-from opentelemetry.sdk.trace.export import Span
+from opentelemetry.sdk.trace import _Span as Span
 from opentelemetry.trace import Link, SpanContext, SpanKind
 from opentelemetry.trace.status import Status as SpanStatus
 from opentelemetry.trace.status import StatusCanonicalCode

--- a/opentelemetry-exporter-google-cloud/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_integration_cloud_trace_exporter.py
@@ -17,7 +17,8 @@ from google.cloud.trace_v2 import TraceServiceClient
 from google.cloud.trace_v2.gapic.transports import trace_service_grpc_transport
 from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace.export import Span, SpanExportResult
+from opentelemetry.sdk.trace import _Span as Span
+from opentelemetry.sdk.trace.export import SpanExportResult
 from opentelemetry.trace import SpanContext, SpanKind
 from opentelemetry.util import time_ns
 

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
@@ -75,7 +75,7 @@ class CloudTraceFormatPropagator(textmap.TextMapPropagator):
         context: typing.Optional[Context] = None,
     ) -> None:
         span = trace.get_current_span(context)
-        span_context = span.get_context()
+        span_context = span.get_span_context()
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return
 

--- a/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
@@ -45,7 +45,7 @@ class TestCloudTraceFormatPropagator(unittest.TestCase):
         """Test helper"""
         header = {_TRACE_CONTEXT_HEADER_NAME: [header_value]}
         new_context = self.propagator.extract(get_dict_value, header)
-        return trace.get_current_span(new_context).get_context()
+        return trace.get_current_span(new_context).get_span_context()
 
     def _inject(self, span=None):
         """Test helper"""
@@ -60,14 +60,14 @@ class TestCloudTraceFormatPropagator(unittest.TestCase):
         header = {}
         new_context = self.propagator.extract(get_dict_value, header)
         self.assertEqual(
-            trace.get_current_span(new_context).get_context(),
-            trace.INVALID_SPAN.get_context(),
+            trace.get_current_span(new_context).get_span_context(),
+            trace.INVALID_SPAN.get_span_context(),
         )
 
     def test_empty_context_header(self):
         header = ""
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
     def test_valid_header(self):
@@ -110,77 +110,77 @@ class TestCloudTraceFormatPropagator(unittest.TestCase):
     def test_invalid_header_format(self):
         header = "invalid_header"
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o=".format(
             get_hexadecimal_trace_id(self.valid_trace_id), self.valid_span_id
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "extra_chars/{}/{};o=1".format(
             get_hexadecimal_trace_id(self.valid_trace_id), self.valid_span_id
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{}extra_chars;o=1".format(
             get_hexadecimal_trace_id(self.valid_trace_id), self.valid_span_id
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o=1extra_chars".format(
             get_hexadecimal_trace_id(self.valid_trace_id), self.valid_span_id
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/;o=1".format(
             get_hexadecimal_trace_id(self.valid_trace_id)
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "/{};o=1".format(self.valid_span_id)
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o={}".format("123", "34", "4")
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
     def test_invalid_trace_id(self):
         header = "{}/{};o={}".format(INVALID_TRACE_ID, self.valid_span_id, 1)
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
         header = "{}/{};o={}".format("0" * 32, self.valid_span_id, 1)
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "0/{};o={}".format(self.valid_span_id, 1)
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "234/{};o={}".format(self.valid_span_id, 1)
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o={}".format(self.too_long_id, self.valid_span_id, 1)
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
     def test_invalid_span_id(self):
@@ -188,28 +188,28 @@ class TestCloudTraceFormatPropagator(unittest.TestCase):
             get_hexadecimal_trace_id(self.valid_trace_id), INVALID_SPAN_ID, 1
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o={}".format(
             get_hexadecimal_trace_id(self.valid_trace_id), "0" * 16, 1
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o={}".format(
             get_hexadecimal_trace_id(self.valid_trace_id), "0", 1
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
         header = "{}/{};o={}".format(
             get_hexadecimal_trace_id(self.valid_trace_id), self.too_long_id, 1
         )
         self.assertEqual(
-            self._extract(header), trace.INVALID_SPAN.get_context()
+            self._extract(header), trace.INVALID_SPAN.get_span_context()
         )
 
     def test_inject_with_no_context(self):


### PR DESCRIPTION
Fixes #78. Main changes:
- `Span.get_context() -> Span.get_span_context()`
- `MetricRecord` now has a `Resource`, so updated the test code
- `Span` was made uninstantiable (per the spec) and instead a private `_Span` subclass is instantiable. We use this only in tests