### PR TITLE
drop python3.4 and fix spacing in setup files

### DIFF
--- a/opentelemetry-exporter-google-cloud/setup.cfg
+++ b/opentelemetry-exporter-google-cloud/setup.cfg
@@ -14,14 +14,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-tools-google-cloud/setup.cfg
+++ b/opentelemetry-tools-google-cloud/setup.cfg
@@ -14,22 +14,21 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    google-auth ~= 1.22
+    google-auth~=1.22
     opentelemetry-api
     opentelemetry-sdk
-    requests ~= 2.24
+    requests~=2.24
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Python 3.4 support was already dropped, but I forgot to remove it from the `setup.cfg` file.