### PR TITLE
fixed more 0.14b0 breakages and updated tests to catch them

### DIFF
--- a/get_mock_server.sh
+++ b/get_mock_server.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Use this envvar when testing a local mock_server binary
+if [ "$SKIP_GET_MOCK_SERVER" == "true" ]; then
+  exit
+fi
+
 VERSION=v2-alpha
 BINARY=mock_server-x64-linux-$VERSION
 if ! [ -e $1/$BINARY ]; then
@@ -7,4 +13,3 @@ if ! [ -e $1/$BINARY ]; then
 fi
 
 ln -sf $1/$BINARY $1/mock_server
-

--- a/opentelemetry-exporter-google-cloud/CHANGELOG.md
+++ b/opentelemetry-exporter-google-cloud/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix breakages for opentelemetry-python v0.14b0
+  ([#79](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/79),
+  [#83](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/83))
+
 ## Version 0.13b0
 
 Released 2020-09-17

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -233,7 +233,7 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
             == MetricDescriptor.MetricKind.CUMULATIVE
         ):
             if (
-                record.instrument.meter.batcher.stateful
+                record.instrument.meter.processor.stateful
                 or updated_key not in self._last_updated
             ):
                 # The aggregation has not reset since the exporter
@@ -279,9 +279,10 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
             if not metric_descriptor:
                 continue
             series = TimeSeries(
-                resource=self._get_monitored_resource(
-                    record.instrument.meter.resource
-                )
+                resource=self._get_monitored_resource(record.resource),
+                # TODO: remove
+                # https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/84
+                metric_kind=metric_descriptor.metric_kind,
             )
             series.metric.type = metric_descriptor.type
             for key, value in record.labels:

--- a/opentelemetry-tools-google-cloud/CHANGELOG.md
+++ b/opentelemetry-tools-google-cloud/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix breakages for opentelemetry-python v0.14b0
+  ([#79](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/79))
+
 ## Version 0.13b0
 
 Released 2020-09-17

--- a/tox.ini
+++ b/tox.ini
@@ -68,12 +68,14 @@ changedir =
   test-exporter: opentelemetry-exporter-google-cloud
   test-tools: opentelemetry-tools-google-cloud
 
+passenv = SKIP_GET_MOCK_SERVER
+
 commands_pre =
   test: pip install .
   test: {toxinidir}/get_mock_server.sh {envbindir}
 
 commands =
-  test: pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml
+  test: pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml {posargs}
 
 whitelist_externals = bash
 


### PR DESCRIPTION
There were some more breakages from v0.14b0 that needed fixing before release. Most of this PR is updating tests to actually catch the breakages in the future.
- Updated unit tests to use autospeccing
- Update the integration tests against GCM Mock api to catch the errors too
  * turns out the cloud monitoring integration tests were passing even though they shouldn't, because we swallow exceptions when `CreateMetricDescriptor()` fails
  * updated tests to fail if there is an error logged from `CreateMetricDescriptor()` failure
  * updated tests/exporter to actually pass
- Updated changelogs