### PR TITLE
upgrade packages for opentelemetry-python 0.15b0

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -10,5 +10,5 @@ Sphinx==3.1.2
 # development before GA. After GA, we will build against specific releases.
 # Bump the commit frequently during development whenever you are missing
 # changes from upstream.
-opentelemetry-api~=0.14b0
-opentelemetry-sdk~=0.14b0
+opentelemetry-api~=0.15b0
+opentelemetry-sdk~=0.15b0

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -105,7 +105,10 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
         if resource_attributes.get("cloud.provider") != "gcp":
             return None
         resource_type = resource_attributes["gcp.resource_type"]
-        if resource_type not in OT_RESOURCE_LABEL_TO_GCP:
+        if (
+            not isinstance(resource_type, str)
+            or resource_type not in OT_RESOURCE_LABEL_TO_GCP
+        ):
             return None
         return MonitoredResource(
             type=resource_type,

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
@@ -56,14 +56,13 @@ class TestCloudMonitoringSpanExporter(BaseExporterIntegrationTest):
             )
         )
         meter = meter_provider.get_meter(__name__)
-        counter = meter.create_metric(
+        counter = meter.create_counter(
             # TODO: remove "opentelemetry/" prefix which is a hack
             # https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/84
             name="opentelemetry/name",
             description="desc",
             unit="1",
             value_type=int,
-            metric_type=metrics.Counter,
         )
         # interval doesn't matter, we don't start the thread and just run
         # tick() instead

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
@@ -45,7 +45,7 @@ from opentelemetry.sdk.trace import Event
 from opentelemetry.sdk.trace import _Span as Span
 from opentelemetry.trace import Link, SpanContext, SpanKind
 from opentelemetry.trace.status import Status as SpanStatus
-from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.trace.status import StatusCode
 
 
 # pylint: disable=too-many-public-methods
@@ -159,7 +159,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
                 }
             ),
             "links": None,
-            "status": None,
+            "status": Status(code=StatusCode.UNSET.value),
             "time_events": None,
             "start_time": None,
             "end_time": None,
@@ -183,19 +183,20 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
 
     def test_extract_status_code(self):
         self.assertEqual(
-            _extract_status(SpanStatus(canonical_code=StatusCanonicalCode.OK)),
-            Status(details=None, code=0),
+            _extract_status(SpanStatus(status_code=StatusCode.OK)),
+            Status(details=None, code=StatusCode.OK.value),
         )
 
     def test_extract_status_code_and_desc(self):
         self.assertEqual(
             _extract_status(
                 SpanStatus(
-                    canonical_code=StatusCanonicalCode.UNKNOWN,
-                    description="error_desc",
+                    status_code=StatusCode.UNSET, description="error_desc",
                 )
             ),
-            Status(details=None, code=2, message="error_desc"),
+            Status(
+                details=None, code=StatusCode.UNSET.value, message="error_desc"
+            ),
         )
 
     def test_extract_empty_attributes(self):

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
@@ -38,11 +38,11 @@ class CloudTraceFormatPropagator(textmap.TextMapPropagator):
 
     def extract(
         self,
-        get_from_carrier: textmap.Getter[textmap.TextMapPropagatorT],
+        getter: textmap.Getter[textmap.TextMapPropagatorT],
         carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
-        header = get_from_carrier(carrier, _TRACE_CONTEXT_HEADER_NAME)
+        header = getter.get(carrier, _TRACE_CONTEXT_HEADER_NAME)
 
         if not header:
             return trace.set_span_in_context(trace.INVALID_SPAN, context)

--- a/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import typing
 import unittest
 
 import opentelemetry.trace as trace
@@ -21,6 +20,7 @@ from opentelemetry.tools.cloud_trace_propagator import (
     _TRACE_CONTEXT_HEADER_NAME,
     CloudTraceFormatPropagator,
 )
+from opentelemetry.trace.propagation import textmap
 from opentelemetry.trace.span import (
     INVALID_SPAN_ID,
     INVALID_TRACE_ID,
@@ -29,9 +29,10 @@ from opentelemetry.trace.span import (
     get_hexadecimal_trace_id,
 )
 
+# def get_dict_value(dict_object: typing.Dict[str, str], key: str) -> str:
+#     return dict_object.get(key, "")
 
-def get_dict_value(dict_object: typing.Dict[str, str], key: str) -> str:
-    return dict_object.get(key, "")
+get_dict_value = textmap.DictGetter()
 
 
 class TestCloudTraceFormatPropagator(unittest.TestCase):

--- a/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
@@ -29,10 +29,7 @@ from opentelemetry.trace.span import (
     get_hexadecimal_trace_id,
 )
 
-# def get_dict_value(dict_object: typing.Dict[str, str], key: str) -> str:
-#     return dict_object.get(key, "")
-
-get_dict_value = textmap.DictGetter()
+dict_getter = textmap.DictGetter()
 
 
 class TestCloudTraceFormatPropagator(unittest.TestCase):
@@ -45,7 +42,7 @@ class TestCloudTraceFormatPropagator(unittest.TestCase):
     def _extract(self, header_value):
         """Test helper"""
         header = {_TRACE_CONTEXT_HEADER_NAME: [header_value]}
-        new_context = self.propagator.extract(get_dict_value, header)
+        new_context = self.propagator.extract(dict_getter, header)
         return trace.get_current_span(new_context).get_span_context()
 
     def _inject(self, span=None):
@@ -59,7 +56,7 @@ class TestCloudTraceFormatPropagator(unittest.TestCase):
 
     def test_no_context_header(self):
         header = {}
-        new_context = self.propagator.extract(get_dict_value, header)
+        new_context = self.propagator.extract(dict_getter, header)
         self.assertEqual(
             trace.get_current_span(new_context).get_span_context(),
             trace.INVALID_SPAN.get_span_context(),


### PR DESCRIPTION
Update for breakages in opentelemetry core 0.15b0 packages. Also tested things manually with a sample app exporting to Cloud Trace and Monitoring.