### PR TITLE
Update example codes, the "create_metric" no longer exists.

### DIFF
--- a/docs/examples/cloud_monitoring/basic_metrics.py
+++ b/docs/examples/cloud_monitoring/basic_metrics.py
@@ -27,12 +27,11 @@ metrics.get_meter_provider().start_pipeline(
     meter, CloudMonitoringMetricsExporter(), 5
 )
 
-requests_counter = meter.create_metric(
+requests_counter = meter.create_counter(
     name="request_counter",
     description="number of requests",
     unit="1",
-    value_type=int,
-    metric_type=Counter,
+    value_type=int
 )
 
 staging_labels = {"environment": "staging"}

--- a/docs/examples/cloud_monitoring/basic_metrics.py
+++ b/docs/examples/cloud_monitoring/basic_metrics.py
@@ -31,7 +31,7 @@ requests_counter = meter.create_counter(
     name="request_counter",
     description="number of requests",
     unit="1",
-    value_type=int
+    value_type=int,
 )
 
 staging_labels = {"environment": "staging"}

--- a/docs/examples/tools/cloud_resource_detector/resource_detector_metrics.py
+++ b/docs/examples/tools/cloud_resource_detector/resource_detector_metrics.py
@@ -35,12 +35,11 @@ metrics.get_meter_provider().start_pipeline(
     meter, CloudMonitoringMetricsExporter(), 5
 )
 
-requests_counter = meter.create_metric(
+requests_counter = meter.create_counter(
     name="request_counter_with_resource",
     description="number of requests",
     unit="1",
-    value_type=int,
-    metric_type=Counter,
+    value_type=int
 )
 
 staging_labels = {"environment": "staging"}

--- a/docs/examples/tools/cloud_resource_detector/resource_detector_metrics.py
+++ b/docs/examples/tools/cloud_resource_detector/resource_detector_metrics.py
@@ -39,7 +39,7 @@ requests_counter = meter.create_counter(
     name="request_counter_with_resource",
     description="number of requests",
     unit="1",
-    value_type=int
+    value_type=int,
 )
 
 staging_labels = {"environment": "staging"}

--- a/opentelemetry-exporter-google-cloud/README.rst
+++ b/opentelemetry-exporter-google-cloud/README.rst
@@ -69,13 +69,11 @@ Metrics
         meter, CloudMonitoringMetricsExporter(), 5
     )
 
-    requests_counter = meter.create_metric(
+    requests_counter = meter.create_counter(
         name="request_counter",
         description="number of requests",
         unit="1",
-        value_type=int,
-        metric_type=Counter,
-        label_keys=("environment"),
+        value_type=int
     )
 
     staging_labels = {"environment": "staging"}


### PR DESCRIPTION
Update example codes, the "create_metric" no longer exists in the latest version.