### PR TITLE
remove non-inclusive language from pylintrc where possible

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,15 +1,10 @@
 [MASTER]
 
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code.
-extension-pkg-whitelist=
-
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=CVS,gen,proto
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.
 ignore-patterns=
 


### PR DESCRIPTION
I could not remove "MASTER" because it is part of the pylintrc config format ([see here](https://github.com/PyCQA/pylint/blob/8649b721560ac33756792e405a6d7bbf7d331e57/pylint/constants.py#L39))

The same issue exists in OTel python https://github.com/open-telemetry/opentelemetry-python/issues/1076