### PR TITLE
upgrade OTel python to 0.17b0, small fixes

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,5 +1,8 @@
 allowedLicenses:
   - Apache-2.0
+allowedCopyrightHolders:
+  - Google
+  - OpenTelemetry Authors
 sourceFileExtensions:
   - py
   - sh

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -10,5 +10,5 @@ Sphinx==3.1.2
 # development before GA. After GA, we will build against specific releases.
 # Bump the commit frequently during development whenever you are missing
 # changes from upstream.
-opentelemetry-api~=0.16b1
-opentelemetry-sdk~=0.16b1
+opentelemetry-api~=0.17b0
+opentelemetry-sdk~=0.17b0

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -388,7 +388,9 @@ def _extract_attributes(
     add_agent_attr: bool = False,
 ) -> ProtoSpan.Attributes:
     """Convert span.attributes to dict."""
-    attributes_dict = BoundedDict(num_attrs_limit)
+    attributes_dict = BoundedDict(
+        num_attrs_limit
+    )  # type: BoundedDict[str, AttributeValue]
     invalid_value_dropped_count = 0
     for key, value in attrs.items() if attrs else []:
         key = _truncate_str(key, 128)[0]
@@ -411,7 +413,7 @@ def _extract_attributes(
         )
     return ProtoSpan.Attributes(
         attribute_map=attributes_dict,
-        dropped_attributes_count=attributes_dict.dropped
+        dropped_attributes_count=attributes_dict.dropped  # type: ignore[attr-defined]
         + invalid_value_dropped_count,
     )
 

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
@@ -28,6 +28,7 @@ from opentelemetry.trace.span import (
 _TRACE_CONTEXT_HEADER_NAME = "X-Cloud-Trace-Context"
 _TRACE_CONTEXT_HEADER_FORMAT = r"(?P<trace_id>[0-9a-f]{32})\/(?P<span_id>[\d]{1,20});o=(?P<trace_flags>\d+)"
 _TRACE_CONTEXT_HEADER_RE = re.compile(_TRACE_CONTEXT_HEADER_FORMAT)
+_FIELDS = {_TRACE_CONTEXT_HEADER_NAME}
 
 
 class CloudTraceFormatPropagator(textmap.TextMapPropagator):
@@ -85,3 +86,7 @@ class CloudTraceFormatPropagator(textmap.TextMapPropagator):
             int(span_context.trace_flags.sampled),
         )
         set_in_carrier(carrier, _TRACE_CONTEXT_HEADER_NAME, header)
+
+    @property
+    def fields(self) -> typing.Set[str]:
+        return _FIELDS


### PR DESCRIPTION
- Upgrade to latest python SDK
- Add fields
- Typing improvements

Header checker is failing because the modified files are copyrighted to OpenTelemetry Authors.

#97 