### PR TITLE
Add year to OpenTelemetry Authors copyright header for lint checker

### DIFF
--- a/opentelemetry-exporter-google-cloud/setup.py
+++ b/opentelemetry-exporter-google-cloud/setup.py
@@ -1,4 +1,4 @@
-# Copyright OpenTelemetry Authors
+# Copyright 2021 OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -1,4 +1,4 @@
-# Copyright OpenTelemetry Authors
+# Copyright 2021 OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/google/version.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/google/version.py
@@ -1,4 +1,4 @@
-# Copyright OpenTelemetry Authors
+# Copyright 2021 OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-statements
-# Copyright OpenTelemetry Authors
+# Copyright 2021 OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/setup.py
+++ b/opentelemetry-tools-google-cloud/setup.py
@@ -1,4 +1,4 @@
-# Copyright OpenTelemetry Authors
+# Copyright 2021 OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/google/version.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/google/version.py
@@ -1,4 +1,4 @@
-# Copyright OpenTelemetry Authors
+# Copyright 2021 OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
header-checker-lint requires a year in its copyright regex: https://github.com/googleapis/repo-automation-bots/blob/7999fc36b64ded184fbba54dd606633b98e291f7/packages/header-checker-lint/src/header-parser.ts#L23

And the checker passes on this PR