### PR TITLE
Standardize existing "OpenTelemetry Authors" copyrights

### DIFF
--- a/docs/examples/cloud_monitoring/basic_metrics.py
+++ b/docs/examples/cloud_monitoring/basic_metrics.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/examples/tools/cloud_resource_detector/resource_detector_metrics.py
+++ b/docs/examples/tools/cloud_resource_detector/resource_detector_metrics.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/examples/tools/cloud_resource_detector/resource_detector_trace.py
+++ b/docs/examples/tools/cloud_resource_detector/resource_detector_trace.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/examples/tools/cloud_trace_propagator/client.py
+++ b/docs/examples/tools/cloud_trace_propagator/client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/examples/tools/cloud_trace_propagator/server.py
+++ b/docs/examples/tools/cloud_trace_propagator/server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/setup.py
+++ b/opentelemetry-exporter-google-cloud/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/google/version.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/google/version.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-statements
-# Copyright 2021 OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_monitoring_exporter_integration.py
@@ -1,4 +1,4 @@
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_cloud_trace_exporter.py
@@ -1,4 +1,4 @@
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-exporter-google-cloud/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-google-cloud/tests/test_integration_cloud_trace_exporter.py
@@ -1,4 +1,4 @@
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/setup.py
+++ b/opentelemetry-tools-google-cloud/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
@@ -1,4 +1,4 @@
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/google/version.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/google/version.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/tests/test_cloud_trace_propagator.py
@@ -1,4 +1,4 @@
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry-tools-google-cloud/tests/test_gcp_resource_detector.py
+++ b/opentelemetry-tools-google-cloud/tests/test_gcp_resource_detector.py
@@ -1,4 +1,4 @@
-# Copyright The OpenTelemetry Authors
+# Copyright 2021 The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Missed some of the headers in #103 because they had "The" in front... This is hopefully the last of them, all standardized to the same format...

```sh
perl -i -p -e 's/Copyright\ .*OpenTelemetry.*$/Copyright 2021 The OpenTelemetry Authors/' `git ls-files`
```