### PR TITLE
add "The" to copyright check "The OpenTelemetry Authors"

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -2,7 +2,7 @@ allowedLicenses:
   - Apache-2.0
 allowedCopyrightHolders:
   - Google
-  - OpenTelemetry Authors
+  - The OpenTelemetry Authors
 sourceFileExtensions:
   - py
   - sh

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -2,7 +2,7 @@ black~=19.10b0
 flake8~=3.8.3
 isort~=4.3 # pinned for pylint
 mypy~=0.800
-pylint~=2.5.3
+pylint~=2.6.2
 Sphinx==3.1.2
 
 # TODO: #19


### PR DESCRIPTION
The existing copyright headers have "The" which was missing e.g.:
https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/286db5b37eb990937ef9c16466d06e75ac03b212/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py#L1

Tested with [the JS regex](https://github.com/googleapis/repo-automation-bots/blob/28087753bb56a2da23f315892b425933053e1002/packages/header-checker-lint/src/header-parser.ts#L23):

```console
$ node
Welcome to Node.js v12.20.1.
Type ".help" for more information.
>
>
> const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}(-\d{4})?) ([\w\s]+)\.?/;
undefined
> let line = "# Copyright 2021 The OpenTelemetry Authors";
undefined
> line.match(COPYRIGHT_REGEX)
[
  '# Copyright 2021 The OpenTelemetry Authors',
  '#',
  '2021',
  undefined,
  'The OpenTelemetry Authors',  // <-- This is the correct parsing
  index: 0,
  input: '# Copyright 2021 The OpenTelemetry Authors',
  groups: undefined
]
```

Also upgraded pylint because which fixed a broken lint error