### PR TITLE
run lint, mypy, fix tox jobs per package instead of in a single env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ commands:
       - store_artifacts:
           path: .test-results/test-results
 
-
   setup:
     description: Checkout code and install tox
     steps:
@@ -61,7 +60,7 @@ jobs:
       - run_with_pip_cache:
           cache_key_base: lint-python3.8
           steps:
-            - run: tox -e lint-ci
+            - run: tox -f lint-ci
 
   docs:
     executor: dev_python
@@ -70,7 +69,7 @@ jobs:
       - run_with_pip_cache:
           cache_key_base: lint-python3.8
           steps:
-            - run: tox -e docs-ci
+            - run: tox -f docs-ci
       - run:
           name: Upload docs html artifacts
           command: |
@@ -88,7 +87,7 @@ jobs:
       - run_with_pip_cache:
           cache_key_base: mypy-python3.8
           steps:
-            - run: tox -e mypy-ci
+            - run: tox -f mypy-ci
       - store_test_results_command
 
   tests:

--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,6 @@ exclude =
   .tox
   CVS
   .venv*/
-  venv*/
+  *venv*/
   target
   __pycache__

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -4,11 +4,3 @@ isort~=4.3 # pinned for pylint
 mypy~=0.800
 pylint~=2.6.2
 Sphinx==3.1.2
-
-# TODO: #19
-# Require opentelemetry-api/sdk packages from a specific git commit for close
-# development before GA. After GA, we will build against specific releases.
-# Bump the commit frequently during development whenever you are missing
-# changes from upstream.
-opentelemetry-api~=0.17b0
-opentelemetry-sdk~=0.17b0

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,6 +34,11 @@ Guidelines](https://opensource.google/conduct/).
 
 ## Development Instructions
 
+This project is a monorepo for several PyPI packages, each in a
+`opentelemetry-*` subdirectory. Because each package may have different
+dependencies, we use a virtual environment per package which can be created
+with tox.
+
 ### Install tox
 
 This project uses [tox](https://tox.readthedocs.io/en/latest/index.html) for
@@ -43,11 +48,11 @@ development, so make sure it is installed on your system:
 pip install tox tox-factor
 ```
 
-To create the virtual environment `venv/` in the project root for
+To create the virtual environment `venv/` in the root of each package for
 development, run:
 
 ```sh
-tox -e dev
+tox -f dev -pauto
 ```
 
 ### Running tests
@@ -59,7 +64,7 @@ This project supports python versions 3.4 to 3.8. To run tests, use `tox`:
 tox -l
 
 # Run python3.8 exporter tests
-tox -e py38-ci-test-exporter-google-cloud
+tox -e py38-ci-test-exporter
 
 # Run all python3.8 tests in parallel
 tox -f py38-test -pauto
@@ -74,12 +79,15 @@ tox -s true -f ci -pauto
 
 ```sh
 # Run lint checks
-tox -e lint
+tox -f lint
 
 # To fix formatting and import ordering lint issues automatically
-tox -e fix
+tox -f fix
 ```
 
 ### Issues
 
-`tox` usually recreates virtual environments for you whenever the config changes. However, it doesn't fully track external requirements files and your dependencies can be outdated. Either delete the `.tox/` directory or use the `-r` flag with tox to recreate virtual environments.
+`tox` usually recreates virtual environments for you whenever the config
+changes. However, it doesn't fully track external requirements files and your
+dependencies can be outdated. Either delete the `.tox/` directory or use the
+`-r` flag with tox to recreate virtual environments.

--- a/opentelemetry-exporter-google-cloud/setup.cfg
+++ b/opentelemetry-exporter-google-cloud/setup.cfg
@@ -27,8 +27,8 @@ packages=find_namespace:
 install_requires =
     google-cloud-monitoring <2.0.0
     google-cloud-trace >=0.24.0, <1.0.0
-    opentelemetry-api
-    opentelemetry-sdk
+    opentelemetry-api ~= 0.17b0
+    opentelemetry-sdk ~= 0.17b0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-tools-google-cloud/setup.cfg
+++ b/opentelemetry-tools-google-cloud/setup.cfg
@@ -25,10 +25,10 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    google-auth~=1.22
-    opentelemetry-api
-    opentelemetry-sdk
-    requests~=2.24
+    google-auth ~= 1.22
+    opentelemetry-api ~= 0.17b0
+    opentelemetry-sdk ~= 0.17b0
+    requests ~= 2.24
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -3,25 +3,19 @@ skipsdist = True
 skip_missing_interpreters = True
 envlist =
   ; Add the `ci` factor to any env that should be running during CI.
-  py3{5,6,7,8}-ci-test-{exporter,tools}-google-cloud
+  py3{5,6,7,8}-ci-test-{exporter,tools}
+  {lint,mypy}-ci-{exporter,tools}
+  docs-ci
 
-  ; These are development commands and use the same virtualenv.
-  dev
-  docs
-  fix
-  lint
-  mypy
-
-  ; same as dev factors, but includes "ci" factor and uses clean virtualenv
-  {docs,lint,mypy}-ci
+  ; These are development commands and share the same virtualenv *within the
+  ; package root directory* e.g. opentelemetry-tools-google-cloud/venv
+  {dev,fix}-{exporter,tools}
 
 ; this section contains constants that can be referenced elsewhere
 [constants]
 
 base_deps =
-  -c dev-constraints.txt
-  opentelemetry-api
-  opentelemetry-sdk
+  -c {toxinidir}/dev-constraints.txt
   -e {toxinidir}/test-common
 
 dev_basepython = python3.8
@@ -32,8 +26,6 @@ dev_deps =
   isort
   pylint
   mypy
-  -e {toxinidir}/opentelemetry-exporter-google-cloud
-  -e {toxinidir}/opentelemetry-tools-google-cloud
 
 ; CircleCI won't show results if I put them in .test-results directly
 test_results_dir = {toxinidir}/.test-results/test-results
@@ -41,14 +33,11 @@ test_results_dir = {toxinidir}/.test-results/test-results
 lint_commands =
   black . --diff --check
   isort --recursive . --diff --check-only
-  flake8 .
-  bash -c "pylint $(find . -regex '\.\/opentelemetry\-.*\.pyi?$')"
+  flake8 --config {toxinidir}/.flake8 .
+  bash -c "pylint --rcfile {toxinidir}/.pylintrc $(find . -regex '\.\/opentelemetry\-.*\.pyi?$')"
 
-docs_deps =
-  -r docs-requirements.txt
-docs_commands = make -C docs/ clean html
 
-mypy_args = -p opentelemetry --pretty --show-error-codes {posargs}
+mypy_args = src/ --pretty --show-error-codes {posargs}
 
 mypy_commands =
     bash -c 'cd {toxinidir}/opentelemetry-exporter-google-cloud && \
@@ -63,10 +52,11 @@ download = true
 deps =
   test: {[constants]base_deps}
   test: pytest
-
+setenv =
+  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
+  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
 changedir =
-  test-exporter: opentelemetry-exporter-google-cloud
-  test-tools: opentelemetry-tools-google-cloud
+  test: {env:PACKAGE_NAME}
 
 passenv = SKIP_GET_MOCK_SERVER
 
@@ -79,41 +69,58 @@ commands =
 
 whitelist_externals = bash
 
-; dev, lint, and env all use the same virtualenv. To (re)create the virtualenv
-; for development, run `tox -e dev`. To run fixers (black, isort) `tox -e fix`.
-; Lint is run as part of CI as well, so uses a separate.
-[testenv:{dev,docs,fix,lint,mypy}]
+[testenv:{lint,mypy}-ci-{exporter,tools}]
 download = true
 basepython = {[constants]dev_basepython}
-envdir = venv
-
 deps =
   {[constants]dev_deps}
-  {[constants]docs_deps}
+  docs: {[constants]docs_deps}
+setenv =
+  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
+  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
+changedir = {env:PACKAGE_NAME}
+
+commands_pre =
+  pip install .
 
 commands =
-  docs: {[constants]docs_commands}
-  fix: black .
-  fix: isort --recursive .
-  lint: {[constants]lint_commands}
-  mypy: {[constants]mypy_commands}
+  lint: black . --diff --check
+  lint: isort --recursive . --diff --check-only
+  lint: flake8 --config {toxinidir}/.flake8 .
+  lint: pylint --rcfile {toxinidir}/.pylintrc src/ tests/
+
+  mypy: mypy {[constants]mypy_args} --junit-xml {[constants]test_results_dir}/mypy-{env:PACKAGE_NAME}/junit.xml
+
+; TODO: add docs venv
+[testenv:docs-ci]
+deps =
+  -r docs-requirements.txt
+
+commands =
+  make -C docs/ clean html
 
 whitelist_externals =
   make
   bash
 
-[testenv:{docs,lint,mypy}-ci]
+; dev/fix use the same virtualenv. To (re)create the virtualenv
+; for development, run `tox -e dev`. To run fixers (black, isort) `tox -e fix`.
+[testenv:{dev,fix}-{exporter,tools}]
 download = true
 basepython = {[constants]dev_basepython}
+envdir =
+  exporter: opentelemetry-exporter-google-cloud/venv
+  tools: opentelemetry-tools-google-cloud/venv
 deps =
-  !docs: {[constants]dev_deps}
-  docs: {[constants]docs_deps}
+  {[constants]dev_deps}
+  -e {env:PACKAGE_NAME}
+
+setenv =
+  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
+  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
+
+changedir = {env:PACKAGE_NAME}
 
 commands =
-  docs: {[constants]docs_commands}
-  lint: {[constants]lint_commands}
-  mypy: {[constants]mypy_commands}
-
-whitelist_externals =
-  make
-  bash
+  fix: black .
+  fix: isort --recursive .

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ envlist =
 
 ; this section contains constants that can be referenced elsewhere
 [constants]
-
 base_deps =
   -c {toxinidir}/dev-constraints.txt
   -e {toxinidir}/test-common
@@ -30,54 +29,32 @@ dev_deps =
 ; CircleCI won't show results if I put them in .test-results directly
 test_results_dir = {toxinidir}/.test-results/test-results
 
-lint_commands =
-  black . --diff --check
-  isort --recursive . --diff --check-only
-  flake8 --config {toxinidir}/.flake8 .
-  bash -c "pylint --rcfile {toxinidir}/.pylintrc $(find . -regex '\.\/opentelemetry\-.*\.pyi?$')"
-
-
-mypy_args = src/ --pretty --show-error-codes {posargs}
-
-mypy_commands =
-    bash -c 'cd {toxinidir}/opentelemetry-exporter-google-cloud && \
-        mypy {[constants]mypy_args} \
-        --junit-xml {[constants]test_results_dir}/mypy-exporter/junit.xml'
-    bash -c 'cd {toxinidir}/opentelemetry-tools-google-cloud && \
-        mypy {[constants]mypy_args} \
-        --junit-xml {[constants]test_results_dir}/mypy-tools/junit.xml'
-
 [testenv]
 download = true
+setenv =
+  ; for package specific commands, use these envvars to cd into the directory
+  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
+  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
+
+[testenv:py3{5,6,7,8}-ci-test-{exporter,tools}]
 deps =
   test: {[constants]base_deps}
   test: pytest
-setenv =
-  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
-  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
-changedir =
-  test: {env:PACKAGE_NAME}
-
 passenv = SKIP_GET_MOCK_SERVER
+changedir = {env:PACKAGE_NAME}
 
 commands_pre =
-  test: pip install .
-  test: {toxinidir}/get_mock_server.sh {envbindir}
+  pip install .
+  {toxinidir}/get_mock_server.sh {envbindir}
 
-commands =
-  test: pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml {posargs}
+commands = pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml {posargs}
 
 whitelist_externals = bash
 
 [testenv:{lint,mypy}-ci-{exporter,tools}]
-download = true
 basepython = {[constants]dev_basepython}
 deps =
   {[constants]dev_deps}
-  docs: {[constants]docs_deps}
-setenv =
-  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
-  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
 changedir = {env:PACKAGE_NAME}
 
 commands_pre =
@@ -89,9 +66,9 @@ commands =
   lint: flake8 --config {toxinidir}/.flake8 .
   lint: pylint --rcfile {toxinidir}/.pylintrc src/ tests/
 
-  mypy: mypy {[constants]mypy_args} --junit-xml {[constants]test_results_dir}/mypy-{env:PACKAGE_NAME}/junit.xml
+  mypy: mypy src/ --pretty --show-error-codes --junit-xml \
+  mypy:   {[constants]test_results_dir}/mypy-{env:PACKAGE_NAME}/junit.xml {posargs} 
 
-; TODO: add docs venv
 [testenv:docs-ci]
 deps =
   -r docs-requirements.txt
@@ -104,9 +81,8 @@ whitelist_externals =
   bash
 
 ; dev/fix use the same virtualenv. To (re)create the virtualenv
-; for development, run `tox -e dev`. To run fixers (black, isort) `tox -e fix`.
+; for development, run `tox -f dev`. To run fixers (black, isort) `tox -f fix`.
 [testenv:{dev,fix}-{exporter,tools}]
-download = true
 basepython = {[constants]dev_basepython}
 envdir =
   exporter: opentelemetry-exporter-google-cloud/venv
@@ -114,11 +90,6 @@ envdir =
 deps =
   {[constants]dev_deps}
   -e {env:PACKAGE_NAME}
-
-setenv =
-  exporter: PACKAGE_NAME = opentelemetry-exporter-google-cloud
-  tools: PACKAGE_NAME = opentelemetry-tools-google-cloud
-
 changedir = {env:PACKAGE_NAME}
 
 commands =


### PR DESCRIPTION
Fixes #19 

Instead of running lint, mypy, and fix globally over the whole repo, they are now scoped per package and have distinct virtualenvs.

This is needed before splitting up all the packages because the metrics and trace exporters will depend on conflicting versions of `opentelemetry-api`. Also simplified the tox file a good amount.