### PR TITLE
Update packages to 1.x OTel releases

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,9 +35,7 @@ Guidelines](https://opensource.google/conduct/).
 ## Development Instructions
 
 This project is a monorepo for several PyPI packages, each in a
-`opentelemetry-*` subdirectory. Because each package may have different
-dependencies, we use a virtual environment per package which can be created
-with tox.
+`opentelemetry-*` subdirectory.
 
 ### Install tox
 
@@ -48,16 +46,16 @@ development, so make sure it is installed on your system:
 pip install tox tox-factor
 ```
 
-To create the virtual environment `venv/` in the root of each package for
-development, run:
+To create a virtual environment `venv/` at the root of the repository (useful
+for pointing editors like vscode at), run:
 
 ```sh
-tox -f dev -pauto
+tox -e dev
 ```
 
 ### Running tests
 
-This project supports python versions 3.4 to 3.8. To run tests, use `tox`:
+This project supports python versions 3.5 to 3.9. To run tests, use `tox`:
 
 ```sh
 # List all tox environments

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -26,8 +26,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     google-cloud-monitoring <2.0.0
-    opentelemetry-api ~= 0.17b0
-    opentelemetry-sdk ~= 0.17b0
+    opentelemetry-api ~= 1.10a0
+    opentelemetry-sdk ~= 1.10a0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -23,6 +23,7 @@ from google.api.metric_pb2 import MetricDescriptor
 from google.api.monitored_resource_pb2 import MonitoredResource
 from google.cloud.monitoring_v3 import MetricServiceClient
 from google.cloud.monitoring_v3.proto.metric_pb2 import TimeSeries
+from opentelemetry.exporter.cloud_monitoring._time import time_ns
 from opentelemetry.sdk.metrics import UpDownCounter
 from opentelemetry.sdk.metrics.export import (
     ExportRecord,
@@ -35,7 +36,6 @@ from opentelemetry.sdk.metrics.export.aggregate import (
     ValueObserverAggregator,
 )
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.util import time_ns
 
 logger = logging.getLogger(__name__)
 MAX_BATCH_WRITE = 200

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/_time.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/_time.py
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test utilities used across packages
-
-This code is only used in other modules' tests
-"""
-
-
-from .base_exporter_integration_test import BaseExporterIntegrationTest
 
 try:
     from time import time_ns as _time_ns
@@ -37,7 +30,3 @@ def time_ns() -> int:
     TODO: remove when python3.6 is dropped
     """
     return _time_ns()
-
-
-__all__ = ["time_ns", "BaseExporterIntegrationTest"]
-

--- a/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
@@ -149,7 +149,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (),
                     UnsupportedAggregator(),
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 )
             )
         )
@@ -158,7 +158,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             MockMetric(),
             (("label1", "value1"),),
             SumAggregator(),
-            Resource.create_empty(),
+            Resource.get_empty(),
         )
         metric_descriptor = exporter._get_metric_descriptor(record)
         client.create_metric_descriptor.assert_called_with(
@@ -194,7 +194,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     ("label4", False),
                 ),
                 SumAggregator(),
-                Resource.create_empty(),
+                Resource.get_empty(),
             )
         )
         client.create_metric_descriptor.assert_called_with(
@@ -223,10 +223,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         )
         exporter.project_name = self.project_name
         record = ExportRecord(
-            MockMetric(),
-            (),
-            ValueObserverAggregator(),
-            Resource.create_empty(),
+            MockMetric(), (), ValueObserverAggregator(), Resource.get_empty(),
         )
         exporter._get_metric_descriptor(record)
         client.create_metric_descriptor.assert_called_with(
@@ -263,7 +260,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (("label1", "value1"),),
                     UnsupportedAggregator(),
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 )
             ]
         )
@@ -364,13 +361,13 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (("label1", "value1"), ("label2", 1),),
                     sum_agg_two,
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 ),
                 ExportRecord(
                     MockMetric(),
                     (("label1", "value2"), ("label2", 2),),
                     sum_agg_two,
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 ),
             ]
         )
@@ -384,7 +381,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(),
                     (("label1", "changed_label"), ("label2", 2),),
                     sum_agg_two,
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 ),
             ]
         )
@@ -443,7 +440,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(meter=mock_meter()),
                     (),
                     aggregator,
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 )
             ]
         )
@@ -497,7 +494,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                     MockMetric(meter=mock_meter()),
                     (),
                     aggregator,
-                    Resource.create_empty(),
+                    Resource.get_empty(),
                 )
             ]
         )
@@ -556,7 +553,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         agg.last_update_timestamp = (WRITE_INTERVAL + 1) * NANOS_PER_SECOND
 
         metric_record = ExportRecord(
-            MockMetric(stateful=False), (), agg, Resource.create_empty()
+            MockMetric(stateful=False), (), agg, Resource.get_empty()
         )
 
         exporter.export([metric_record])
@@ -579,7 +576,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         agg.last_update_timestamp = (WRITE_INTERVAL * 2 + 2) * NANOS_PER_SECOND
 
         metric_record = ExportRecord(
-            MockMetric(stateful=False), (), agg, Resource.create_empty()
+            MockMetric(stateful=False), (), agg, Resource.get_empty()
         )
 
         exporter.export([metric_record])
@@ -634,7 +631,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         sum_agg_one = SumAggregator()
         sum_agg_one.update(1)
         metric_record = ExportRecord(
-            MockMetric(), (), sum_agg_one, Resource.create_empty()
+            MockMetric(), (), sum_agg_one, Resource.get_empty()
         )
         exporter1.export([metric_record])
         exporter2.export([metric_record])
@@ -658,7 +655,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         exporter = CloudMonitoringMetricsExporter(project_id=self.project_id)
 
         self.assertIsNone(
-            exporter._get_monitored_resource(Resource.create_empty())
+            exporter._get_monitored_resource(Resource.get_empty())
         )
         resource = Resource(
             attributes={

--- a/opentelemetry-exporter-gcp-trace/setup.cfg
+++ b/opentelemetry-exporter-gcp-trace/setup.cfg
@@ -26,8 +26,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     google-cloud-trace >=0.24.0, <1.0.0
-    opentelemetry-api ~= 0.17b0
-    opentelemetry-sdk ~= 0.17b0
+    opentelemetry-api ~= 1.0
+    opentelemetry-sdk ~= 1.0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_exporter.py
@@ -200,12 +200,8 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
 
     def test_extract_status_code_future_added(self):
         self.assertEqual(
-            _extract_status(
-                SpanStatus(
-                    status_code=mock.Mock(), description="unknown_description",
-                )
-            ),
-            Status(code=code_pb2.UNKNOWN, message="unknown_description"),
+            _extract_status(SpanStatus(status_code=mock.Mock(),)),
+            Status(code=code_pb2.UNKNOWN),
         )
 
     def test_extract_empty_attributes(self):
@@ -623,7 +619,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
         )
 
     def test_extract_empty_resources(self):
-        self.assertEqual(_extract_resources(Resource.create_empty()), {})
+        self.assertEqual(_extract_resources(Resource.get_empty()), {})
 
     def test_extract_well_formed_resources(self):
         resource = Resource(

--- a/opentelemetry-exporter-gcp-trace/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-gcp-trace/tests/test_integration_cloud_trace_exporter.py
@@ -20,9 +20,8 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import _Span as Span
 from opentelemetry.sdk.trace.export import SpanExportResult
 from opentelemetry.trace import SpanContext, SpanKind
-from opentelemetry.util import time_ns
 
-from test_common import BaseExporterIntegrationTest
+from test_common import BaseExporterIntegrationTest, time_ns
 
 
 class TestCloudTraceSpanExporter(BaseExporterIntegrationTest):

--- a/opentelemetry-propagator-gcp/setup.cfg
+++ b/opentelemetry-propagator-gcp/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api ~= 0.17b0
+    opentelemetry-api ~= 1.0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-resourcedetector-gcp/setup.cfg
+++ b/opentelemetry-resourcedetector-gcp/setup.cfg
@@ -26,8 +26,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     google-auth ~= 1.22
-    opentelemetry-api ~= 0.17b0
-    opentelemetry-sdk ~= 0.17b0
+    opentelemetry-api ~= 1.0
+    opentelemetry-sdk ~= 1.0
     requests ~= 2.24
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,13 @@ envlist =
   {lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   docs-ci
 
-  ; These are development commands and share the same virtualenv *within the
-  ; package root directory* e.g. opentelemetry-tools-google-cloud/venv
-  {dev,fix}-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
+  ; These are development commands and share the same virtualenv within each
+  ; package root directory
+  {fix}-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
+
+  ; Installs dev depenedencies and all packages in this repo with editable
+  ; install into a single env. Useful for editor autocompletion
+  dev
 
 ; this section contains constants that can be referenced elsewhere
 [constants]
@@ -82,9 +86,7 @@ whitelist_externals =
   make
   bash
 
-; dev/fix use the same virtualenv. To (re)create the virtualenv
-; for development, run `tox -f dev`. To run fixers (black, isort) `tox -f fix`.
-[testenv:{dev,fix}-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
+[testenv:{fix}-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 basepython = {[constants]dev_basepython}
 envdir =
   cloudtrace: opentelemetry-exporter-gcp-trace/venv
@@ -97,5 +99,16 @@ deps =
 changedir = {env:PACKAGE_NAME}
 
 commands =
+  ; To run fixers (black, isort) `tox -f fix`.
   fix: black .
   fix: isort --recursive .
+
+[testenv:dev]
+basepython = {[constants]dev_basepython}
+envdir = venv
+deps =
+  {[constants]dev_deps}
+  -e opentelemetry-exporter-gcp-monitoring
+  -e opentelemetry-exporter-gcp-trace
+  -e opentelemetry-propagator-gcp
+  -e opentelemetry-resourcedetector-gcp


### PR DESCRIPTION
- Updated packages for 1.x OTel releases
  - Trace exporter, propagator, and resource detector depend on `~=1.0`
  - Metric exporter depends on `~=1.10a0` which contains metrics API/SDK now upstream
  - Mostly propagator changes and renames
- Create a single dev env again in tox
