### PR TITLE
release pr/1.0.0rc0

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-monitoring/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.0.0a0
+
+Released 2021-04-22
+
 - Drop support for Python 3.5
   ([#123](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/123))
 - Split cloud trace and cloud monitoring exporters into separate packages

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0a0"
+__version__ = "1.1.0.dev0"

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.19.dev0"
+__version__ = "1.0.0a0"

--- a/opentelemetry-exporter-gcp-trace/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-trace/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.0.0rc0
+
+Released 2021-04-22
+
 - Drop support for Python 3.5
   ([#123](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/123))
 - Split cloud trace and cloud monitoring exporters into separate packages

--- a/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
+++ b/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.19.dev0"
+__version__ = "1.0.0rc0"

--- a/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
+++ b/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0rc0"
+__version__ = "1.1.0.dev0"

--- a/opentelemetry-propagator-gcp/CHANGELOG.md
+++ b/opentelemetry-propagator-gcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.0.0rc0
+
+Released 2021-04-22
+
 - Drop support for Python 3.5
   ([#123](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/123))
 - Split tools package into separate propagator and resource detector packages

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.19.dev0"
+__version__ = "1.0.0rc0"

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0rc0"
+__version__ = "1.1.0.dev0"

--- a/opentelemetry-resourcedetector-gcp/CHANGELOG.md
+++ b/opentelemetry-resourcedetector-gcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.0.0a0
+
+Released 2021-04-22
+
 - Drop support for Python 3.5
   ([#123](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/123))
 - Split tools package into separate propagator and resource detector packages

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0a0"
+__version__ = "1.1.0.dev0"

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.19.dev0"
+__version__ = "1.0.0a0"


### PR DESCRIPTION
Please review the two comments individually:
- Release 1.0.0rc0 (Part 1/2) release commit
- Release 1.0.0rc0 (Part 2/2) bump version to 1.1.0.dev0

This PR generated by `release.py` script in PR #132 with

```bash
./release.py \
  --release_version 1.0.0rc0 \
  --new_dev_version 1.1.0.dev0 \
  --alternate_suffix 'opentelemetry-exporter-gcp-monitoring:a0' \
  --alternate_suffix 'opentelemetry-resourcedetector-gcp:a0'
```

----

The packages versions released from here is
- 1.0.0rc0 (release candidate) for `opentelemetry-propagator-gcp` and `opentelemetry-exporter-gcp-trace`
- 1.0.0a0 (alpha) for `opentelemetry-resourcedetector-gcp` and `opentelemetry-exporter-gcp-monitoring`