### PR TITLE
Run e2e tests on gke and gce

### DIFF
--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -1,0 +1,37 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Wait for the image to exist
+  - name: "docker"
+    id: wait-for-image
+    entrypoint: "sh"
+    timeout: 3m
+    env: ["_TEST_SERVER_IMAGE=${_TEST_SERVER_IMAGE}"]
+    args:
+      - e2e-test-server/wait-for-image.sh
+
+  # Run the test
+  - name: $_TEST_RUNNER_IMAGE
+    id: run-tests-gce
+    dir: /
+    env: ["PROJECT_ID=$PROJECT_ID"]
+    args:
+      - gce
+      - --image=$_TEST_SERVER_IMAGE
+
+logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+substitutions:
+  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.22
+  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-python-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -1,0 +1,36 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0 #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Wait for the image to exist
+  - name: "docker"
+    id: wait-for-image
+    entrypoint: "sh"
+    timeout: 3m
+    env: ["_TEST_SERVER_IMAGE=${_TEST_SERVER_IMAGE}"]
+    args:
+      - e2e-test-server/wait-for-image.sh
+
+  # Run the test
+  - name: $_TEST_RUNNER_IMAGE
+    id: run-tests-gke
+    dir: /
+    env: ["PROJECT_ID=$PROJECT_ID"]
+    args:
+      - gke
+      - --image=$_TEST_SERVER_IMAGE
+
+logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+substitutions:
+  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.22
+  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-python-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -1,0 +1,38 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Wait for the image to exist
+  - name: "docker"
+    id: wait-for-image
+    entrypoint: "sh"
+    timeout: 3m
+    env: ["_TEST_SERVER_IMAGE=${_TEST_SERVER_IMAGE}"]
+    args:
+      - e2e-test-server/wait-for-image.sh
+
+  # Run the test
+  - name: $_TEST_RUNNER_IMAGE
+    id: run-tests-local
+    dir: /
+    env: ["PROJECT_ID=$PROJECT_ID"]
+    args:
+      - local
+      - --image=$_TEST_SERVER_IMAGE
+      - --network=cloudbuild
+
+logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+substitutions:
+  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.22
+  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-python-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,32 +13,40 @@
 # limitations under the License.
 
 steps:
+  # If the image doesn't exist, create a skip file for the next step to know
+  - name: "gcr.io/cloud-builders/gcloud"
+    entrypoint: "bash"
+    args:
+      - -c
+      - |
+        existing_tags=$(
+          gcloud container images list-tags \
+            --filter="tags:${SHORT_SHA}" --format=json \
+            ${_TEST_SERVER_IMAGE_NAME}
+        )
+
+        if [ "$existing_tags" == "[]" ]; then
+          echo "Image doesn't exist, will build it"
+        else
+          echo "Image already exists, will skip building"
+          touch skip
+        fi
+
+  # If skip doesn't exist, build and push
   - name: docker
     id: build-test-server
+    entrypoint: "sh"
     args:
-      - build
-      - --tag=$_TEST_SERVER_IMAGE
-      - --file=e2e-test-server/Dockerfile
-      - .
-  - name: docker
-    id: push-test-server-image
-    args:
-      - push
-      - $_TEST_SERVER_IMAGE
-
-  - name: $_TEST_RUNNER_IMAGE
-    id: run-tests
-    dir: /
-    env:
-      - "PROJECT_ID=$PROJECT_ID"
-    args:
-      - local
-      - --image=$_TEST_SERVER_IMAGE
-      - --network=cloudbuild
+      - -c
+      - |
+        if [ -e "skip" ]; then
+          return
+        else
+          docker build --tag=${_TEST_SERVER_IMAGE} --file=e2e-test-server/Dockerfile .
+          docker push ${_TEST_SERVER_IMAGE}
+        fi
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.22
-  _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-python-e2e-test-server:${SHORT_SHA}
-images:
-  - $_TEST_SERVER_IMAGE
+  _TEST_SERVER_IMAGE: ${_TEST_SERVER_IMAGE_NAME}:${SHORT_SHA}
+  _TEST_SERVER_IMAGE_NAME: gcr.io/${PROJECT_ID}/opentelemetry-operations-python-e2e-test-server

--- a/e2e-test-server/wait-for-image.sh
+++ b/e2e-test-server/wait-for-image.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# 
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+while true; do
+    docker pull $_TEST_SERVER_IMAGE
+    pull_success=$?
+
+    if [ $pull_success -ne 0 ]; then
+        echo "Image couldn't be pulled yet, will continue to retry"
+    else
+        echo "Image pulled successfully, continuing onto test"
+        break
+    fi
+    sleep 5
+done


### PR DESCRIPTION
- Move the docker build step into its own yaml
- Make individual build triggers and yaml files for each of local, gce, gke. Each of these block on the docker build (with timeout)
