### PR TITLE
add deprecation warnings for opentelemetry-exporter-cloud-monitoring and opentelemetry-exporter-cloud-trace

### DIFF
--- a/opentelemetry-exporter-cloud-monitoring/README.rst
+++ b/opentelemetry-exporter-cloud-monitoring/README.rst
@@ -1,6 +1,14 @@
 OpenTelemetry Cloud Monitoring Exporters
 ========================================
 
+DEPRECATED
+----------
+
+**This package is deprecated. It will not
+receive any more updates.** Please use `opentelemetry-exporter-gcp-monitoring
+<https://pypi.org/project/opentelemetry-exporter-gcp-monitoring/>`_ instead. It
+will not receive any more updates.
+
 This library provides classes for exporting metrics data to Google Cloud Monitoring.
 
 Installation

--- a/opentelemetry-exporter-cloud-monitoring/setup.cfg
+++ b/opentelemetry-exporter-cloud-monitoring/setup.cfg
@@ -15,7 +15,7 @@
 #
 [metadata]
 name = opentelemetry-exporter-cloud-monitoring
-description = Cloud Monitoring integration for OpenTelemetry
+description = Deprecated Cloud Monitoring integration for OpenTelemetry
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = OpenTelemetry Authors

--- a/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import random
 from typing import Optional, Sequence

--- a/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -15,6 +15,14 @@ from opentelemetry.sdk.metrics.export import (
 )
 from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
 
+import warnings
+
+warnings.warn(
+    "Package opentelemetry-exporter-cloud-monitoring is deprecated. Please install "
+    "opentelemetry-exporter-gcp-monitoring instead",
+    DeprecationWarning,
+)
+
 logger = logging.getLogger(__name__)
 MAX_BATCH_WRITE = 200
 WRITE_INTERVAL = 10

--- a/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
+++ b/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10b0"
+__version__ = "0.10b1"

--- a/opentelemetry-exporter-cloud-monitoring/tests/__init__.py
+++ b/opentelemetry-exporter-cloud-monitoring/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/opentelemetry-exporter-cloud-trace/README.rst
+++ b/opentelemetry-exporter-cloud-trace/README.rst
@@ -1,6 +1,16 @@
 OpenTelemetry Cloud Trace Exporters
 ===================================
 
+DEPRECATED
+----------
+
+**This package is deprecated. It will not
+receive any more updates.** Please use `opentelemetry-exporter-gcp-trace
+<https://pypi.org/project/opentelemetry-exporter-gcp-trace/>`_ and
+`opentelemetry-propagator-gcp
+<https://pypi.org/project/opentelemetry-propagator-gcp/>`_ instead. It will not
+receive any more updates.
+
 This library provides classes for exporting trace data to Google Cloud Trace.
 
 Installation

--- a/opentelemetry-exporter-cloud-trace/setup.cfg
+++ b/opentelemetry-exporter-cloud-trace/setup.cfg
@@ -14,7 +14,7 @@
 #
 [metadata]
 name = opentelemetry-exporter-cloud-trace
-description = Cloud Trace integration for OpenTelemetry
+description = Deprecated Cloud Trace integration for OpenTelemetry
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = OpenTelemetry Authors

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -64,6 +64,14 @@ from opentelemetry.trace.span import (
 )
 from opentelemetry.util import types
 
+import warnings
+
+warnings.warn(
+    "Package opentelemetry-exporter-cloud-monitoring is deprecated. Please install "
+    "opentelemetry-exporter-gcp-monitoring instead",
+    DeprecationWarning,
+)
+
 logger = logging.getLogger(__name__)
 
 MAX_NUM_LINKS = 128

--- a/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/version.py
+++ b/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10b0"
+__version__ = "0.10b1"

--- a/opentelemetry-exporter-cloud-trace/tests/__init__.py
+++ b/opentelemetry-exporter-cloud-trace/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+


### PR DESCRIPTION
I created a new orphan branch with the old code (it was in opentelemetry-python upstream repo) [final-release-old-exporters-0.10b1](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/final-release-old-exporters-0.10b1). This PR modifies that to warn in code and in the READMEs on pypi that this package is deprecated and what to use instead.

I also bumped the versions to `0.10b1`. I'll release these packages once more with just these modifications. You can ignore test failures, this code doesn't have any CI stuff.