### PR TITLE
add deprecation warnings for opentelemetry-exporter-google-cloud and opentelemetry-tools-google-cloud

### DIFF
--- a/opentelemetry-exporter-google-cloud/README.rst
+++ b/opentelemetry-exporter-google-cloud/README.rst
@@ -8,6 +8,16 @@ OpenTelemetry Google Cloud Integration
     :target: https://google-cloud-opentelemetry.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+DEPRECATED
+----------
+
+**This package is deprecated. It will not
+receive any more updates.** Please use `opentelemetry-exporter-gcp-monitoring
+<https://pypi.org/project/opentelemetry-exporter-gcp-monitoring/>`_ and
+`opentelemetry-exporter-gcp-trace
+<https://pypi.org/project/opentelemetry-exporter-gcp-trace/>`_ instead. It will
+not receive any more updates.
+
 This library provides support for:
 
 - Exporting traces to Google Cloud Trace

--- a/opentelemetry-exporter-google-cloud/setup.cfg
+++ b/opentelemetry-exporter-google-cloud/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = opentelemetry-exporter-google-cloud
-description = Google Cloud integrations for OpenTelemetry
+description = Deprecated Google Cloud integrations for OpenTelemetry
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Google

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -14,6 +14,7 @@
 
 import logging
 import random
+import warnings
 from typing import Optional, Sequence
 
 import google.auth
@@ -36,8 +37,6 @@ from opentelemetry.sdk.metrics.export.aggregate import (
 )
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.util import time_ns
-
-import warnings
 
 warnings.warn(
     "Package opentelemetry-exporter-google-cloud is deprecated. Please install "

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -37,6 +37,14 @@ from opentelemetry.sdk.metrics.export.aggregate import (
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.util import time_ns
 
+import warnings
+
+warnings.warn(
+    "Package opentelemetry-exporter-google-cloud is deprecated. Please install "
+    "opentelemetry-exporter-gcp-monitoring and opentelemetry-exporter-gcp-trace instead",
+    DeprecationWarning,
+)
+
 logger = logging.getLogger(__name__)
 MAX_BATCH_WRITE = 200
 WRITE_INTERVAL = 10

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -50,6 +50,7 @@ API
 
 import collections
 import logging
+import warnings
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import google.auth
@@ -72,8 +73,6 @@ from opentelemetry.trace.span import (
 )
 from opentelemetry.trace.status import StatusCode
 from opentelemetry.util import types
-
-import warnings
 
 warnings.warn(
     "Package opentelemetry-exporter-google-cloud is deprecated. Please install "

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -73,6 +73,14 @@ from opentelemetry.trace.span import (
 from opentelemetry.trace.status import StatusCode
 from opentelemetry.util import types
 
+import warnings
+
+warnings.warn(
+    "Package opentelemetry-exporter-google-cloud is deprecated. Please install "
+    "opentelemetry-exporter-gcp-monitoring and opentelemetry-exporter-gcp-trace instead",
+    DeprecationWarning,
+)
+
 logger = logging.getLogger(__name__)
 
 MAX_NUM_LINKS = 128

--- a/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/google/version.py
+++ b/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/google/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18b0"
+__version__ = "0.18b1"

--- a/opentelemetry-tools-google-cloud/README.rst
+++ b/opentelemetry-tools-google-cloud/README.rst
@@ -8,6 +8,16 @@ OpenTelemetry Google Cloud Integration
     :target: https://google-cloud-opentelemetry.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+DEPRECATED
+----------
+
+**This package is deprecated. It will not
+receive any more updates.** Please use `opentelemetry-resourcedetector-gcp
+<https://pypi.org/project/opentelemetry-resourcedetector-gcp/>`_ and
+`opentelemetry-propagator-gcp
+<https://pypi.org/project/opentelemetry-propagator-gcp/>`_ instead. It will not
+receive any more updates.
+
 This library provides support for:
 
 - Detecting GCP resources like GCE, GKE, etc.

--- a/opentelemetry-tools-google-cloud/setup.cfg
+++ b/opentelemetry-tools-google-cloud/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = opentelemetry-tools-google-cloud
-description = Google Cloud propagator and resource detector for OpenTelemetry
+description = Deprecated Google Cloud propagator and resource detector for OpenTelemetry
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Google

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
@@ -15,6 +15,7 @@
 
 import re
 import typing
+import warnings
 
 import opentelemetry.trace as trace
 from opentelemetry.context.context import Context
@@ -24,8 +25,6 @@ from opentelemetry.trace.span import (
     TraceFlags,
     get_hexadecimal_trace_id,
 )
-
-import warnings
 
 warnings.warn(
     "Package opentelemetry-tools-google-cloud is deprecated. Please install "

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/cloud_trace_propagator.py
@@ -25,6 +25,14 @@ from opentelemetry.trace.span import (
     get_hexadecimal_trace_id,
 )
 
+import warnings
+
+warnings.warn(
+    "Package opentelemetry-tools-google-cloud is deprecated. Please install "
+    "opentelemetry-resourcedetector-gcp and opentelemetry-propagator-gcp instead",
+    DeprecationWarning,
+)
+
 _TRACE_CONTEXT_HEADER_NAME = "x-cloud-trace-context"
 _TRACE_CONTEXT_HEADER_FORMAT = r"(?P<trace_id>[0-9a-f]{32})\/(?P<span_id>[\d]{1,20});o=(?P<trace_flags>\d+)"
 _TRACE_CONTEXT_HEADER_RE = re.compile(_TRACE_CONTEXT_HEADER_FORMAT)

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/google/version.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/google/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18b0"
+__version__ = "0.18b1"

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/resource_detector.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/resource_detector.py
@@ -19,6 +19,14 @@ import requests
 from opentelemetry.context import attach, detach, set_value
 from opentelemetry.sdk.resources import Resource, ResourceDetector
 
+import warnings
+
+warnings.warn(
+    "Package opentelemetry-exporter-cloud-monitoring is deprecated. Please install "
+    "opentelemetry-exporter-gcp-monitoring instead",
+    DeprecationWarning,
+)
+
 _GCP_METADATA_URL = (
     "http://metadata.google.internal/computeMetadata/v1/?recursive=true"
 )

--- a/opentelemetry-tools-google-cloud/src/opentelemetry/tools/resource_detector.py
+++ b/opentelemetry-tools-google-cloud/src/opentelemetry/tools/resource_detector.py
@@ -14,12 +14,11 @@
 
 import logging
 import os
+import warnings
 
 import requests
 from opentelemetry.context import attach, detach, set_value
 from opentelemetry.sdk.resources import Resource, ResourceDetector
-
-import warnings
 
 warnings.warn(
     "Package opentelemetry-exporter-cloud-monitoring is deprecated. Please install "


### PR DESCRIPTION
Same changes as #142 but for opentelemetry-exporter-google-cloud and opentelemetry-tools-google-cloud with final release version 0.18b1. These packages are deprecated.