### PR TITLE
bump pylint version to fix lint failures

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -2,5 +2,5 @@ black~=19.10b0
 flake8~=3.8.3
 isort~=4.3 # pinned for pylint
 mypy~=0.800
-pylint~=2.7.4
+pylint~=2.8.3
 Sphinx==3.1.2


### PR DESCRIPTION
For some reason, lint is failing in main branch even though we didn't change anything. Bumping the version solved it