### PR TITLE
Upgrade google-cloud-trace dep to ~=1.1

### DIFF
--- a/e2e-test-server/constraints.txt
+++ b/e2e-test-server/constraints.txt
@@ -5,9 +5,8 @@ click==7.1.2
 Flask==1.1.2
 google-api-core==1.26.3
 google-auth==1.30.0
-google-cloud-core==1.6.0
 google-cloud-pubsub==2.4.1
-google-cloud-trace==0.24.0
+google-cloud-trace==1.5.0
 googleapis-common-protos==1.53.0
 grpc-google-iam-v1==0.12.3
 grpcio==1.37.0

--- a/opentelemetry-exporter-gcp-trace/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-trace/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add optional resource attributes to trace spans with regex
   ([#145](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/145))
+- Upgrade `google-cloud-trace` dependency to version 1.1 or newer.
 
 ## Version 1.0.0
 

--- a/opentelemetry-exporter-gcp-trace/setup.cfg
+++ b/opentelemetry-exporter-gcp-trace/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    google-cloud-trace >=0.24.0, <1.0.0
+    google-cloud-trace ~= 1.1
     opentelemetry-api ~= 1.0
     opentelemetry-sdk ~= 1.0
 

--- a/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_exporter.py
@@ -17,9 +17,9 @@ import unittest
 from unittest import mock
 
 import pkg_resources
-from google.cloud.trace_v2.proto.trace_pb2 import AttributeValue
-from google.cloud.trace_v2.proto.trace_pb2 import Span as ProtoSpan
-from google.cloud.trace_v2.proto.trace_pb2 import TruncatableString
+from google.cloud.trace_v2.types import AttributeValue, BatchWriteSpansRequest
+from google.cloud.trace_v2.types import Span as ProtoSpan
+from google.cloud.trace_v2.types import TruncatableString
 from google.rpc import code_pb2
 from google.rpc.status_pb2 import Status
 from opentelemetry.exporter.cloud_trace import (
@@ -175,7 +175,10 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
 
         self.assertTrue(client.batch_write_spans.called)
         client.batch_write_spans.assert_called_with(
-            "projects/{}".format(self.project_id), [cloud_trace_spans]
+            request=BatchWriteSpansRequest(
+                name="projects/{}".format(self.project_id),
+                spans=[cloud_trace_spans],
+            )
         )
 
     def test_extract_status_code_unset(self):

--- a/opentelemetry-exporter-gcp-trace/tests/test_integration_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-gcp-trace/tests/test_integration_cloud_trace_exporter.py
@@ -14,7 +14,9 @@
 
 import grpc
 from google.cloud.trace_v2 import TraceServiceClient
-from google.cloud.trace_v2.gapic.transports import trace_service_grpc_transport
+from google.cloud.trace_v2.services.trace_service.transports.grpc import (
+    TraceServiceGrpcTransport,
+)
 from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import _Span as Span
@@ -58,9 +60,8 @@ class TestCloudTraceSpanExporter(BaseExporterIntegrationTest):
 
         # Setup the trace exporter.
         channel = grpc.insecure_channel(self.address)
-        transport = trace_service_grpc_transport.TraceServiceGrpcTransport(
-            channel=channel
-        )
+        transport = TraceServiceGrpcTransport(channel=channel)
+
         client = TraceServiceClient(transport=transport)
         trace_exporter = CloudTraceSpanExporter(self.project_id, client=client)
 


### PR DESCRIPTION
Fixes #164 

- Updated dependency specifier to newer version
- New client library versions use proto-plus generated classes, which don't mix well with dictionaries (see https://github.com/googleapis/proto-plus-python/issues/161) so updated code to use the generated types