### PR TITLE
Fix build dependency issues

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -1,4 +1,4 @@
-black==21.5b2
+black==22.3.0
 flake8==3.9.2
 isort==5.8.0
 mypy==0.910

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -26,8 +26,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     google-cloud-monitoring <2.0.0
-    opentelemetry-api ~= 1.10a0
-    opentelemetry-sdk ~= 1.10a0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 MAX_BATCH_WRITE = 200
 WRITE_INTERVAL = 10
 UNIQUE_IDENTIFIER_KEY = "opentelemetry_id"
-NANOS_PER_SECOND = 10 ** 9
+NANOS_PER_SECOND = 10**9
 
 OT_RESOURCE_LABEL_TO_GCP = {
     "gce_instance": {
@@ -95,7 +95,7 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
         self.unique_identifier = None
         if add_unique_identifier:
             self.unique_identifier = "{:08x}".format(
-                random.randint(0, 16 ** 8)
+                random.randint(0, 16**8)
             )
 
         (


### PR DESCRIPTION
- See https://github.com/psf/black/issues/2964
- And tightened version specifier for Cloud Monitoring exporter which uses a very outdated version of opentelemetry (old metrics impl)