### PR TITLE
Add entry point for x-cloud-trace-context propagator

### DIFF
--- a/docs/cloud_trace/cloud_trace_propagator.rst
+++ b/docs/cloud_trace/cloud_trace_propagator.rst
@@ -1,0 +1,11 @@
+OpenTelemetry Cloud Trace Propagator
+==================================
+
+.. image:: https://badge.fury.io/py/opentelemetry-propagator-gcp.svg
+    :target: https://badge.fury.io/py/opentelemetry-propagator-gcp
+
+.. automodule:: opentelemetry.propagators.cloud_trace_propagator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,9 +49,10 @@ To install the GCP trace propagator:
    :maxdepth: 1
    :caption: Exporters
    :name: exporters
+   :glob:
 
-   cloud_monitoring/cloud_monitoring
-   cloud_trace/cloud_trace
+   cloud_monitoring/**
+   cloud_trace/**
 
 
 .. toctree::

--- a/opentelemetry-propagator-gcp/setup.cfg
+++ b/opentelemetry-propagator-gcp/setup.cfg
@@ -32,3 +32,7 @@ where = src
 
 [options.extras_require]
 test =
+
+[options.entry_points]
+opentelemetry_propagator =
+    gcp_trace = opentelemetry.propagators.cloud_trace_propagator:CloudTraceFormatPropagator

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
@@ -11,7 +11,38 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+"""Cloud Trace Span Propagator for X-Cloud-Trace-Context format.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry.propagate import set_global_textmap
+    from opentelemetry.propagators.cloud_trace_propagator import (
+        CloudTraceFormatPropagator,
+    )
+
+    # Set the X-Cloud-Trace-Context header
+    set_global_textmap(CloudTraceFormatPropagator())
+
+Auto-instrumentation
+--------------------
+
+This exporter can also be used with the :envvar:`OTEL_PROPAGATORS` environment variable as
+``OTEL_PROPAGATORS=gcp_trace``.
+
+This also works with `OpenTelemetry auto-instrumentation
+<https://opentelemetry.io/docs/instrumentation/python/automatic/>`_:
+
+.. code-block:: sh
+
+    opentelemetry-instrument --propagator gcp_trace <command> <args>
+
+API
+---
+"""
 
 import re
 import typing

--- a/opentelemetry-propagator-gcp/tests/test_cloud_trace_propagator_auto_instrument.py
+++ b/opentelemetry-propagator-gcp/tests/test_cloud_trace_propagator_auto_instrument.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from opentelemetry.environment_variables import OTEL_PROPAGATORS
+from opentelemetry.propagators.cloud_trace_propagator import (
+    CloudTraceFormatPropagator,
+)
+
+
+class TestCloudTracePropagatorAutoInstrument(TestCase):
+    @patch.dict("os.environ", {OTEL_PROPAGATORS: "gcp_trace"})
+    def test_loads_cloud_trace_propagator(self):
+        # This test is a bit fragile as the propagator entry points are loaded on the first
+        # import of opentelemetry.propagate and saved in a global variable. If another tests
+        # imports that before this one, it can fail.
+        # pylint: disable=import-outside-toplevel
+        from opentelemetry.propagate import propagators
+
+        self.assertEqual(len(propagators), 1)
+        self.assertIsInstance(propagators[0], CloudTraceFormatPropagator)


### PR DESCRIPTION
Like #179, this makes it possible to use the trace propagator with environment variables and auto instrumentation. Updated docs can be seen at https://output.circle-artifacts.com/output/job/d6949a7c-a9af-4cea-bc6c-89aa4e22fbd6/artifacts/0/docs-html/cloud_trace/cloud_trace_propagator.html