### PR TITLE
Update no container name behaviour

### DIFF
--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/__init__.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/__init__.py
@@ -61,14 +61,15 @@ def get_gce_resources():
 
 def get_gke_resources():
     """Resource finder for GKE attributes"""
-    # The user must specify the container name via the Downward API
-    container_name = os.getenv("CONTAINER_NAME")
-    if container_name is None:
-        return {}
+
     (
         common_attributes,
         all_metadata,
     ) = _get_google_metadata_and_common_attributes()
+
+    container_name = os.getenv("CONTAINER_NAME")
+    if container_name is not None:
+        common_attributes["container.name"] = container_name
 
     # Fallback to reading namespace from a file is the env var is not set
     pod_namespace = os.getenv("NAMESPACE")
@@ -89,7 +90,6 @@ def get_gke_resources():
             "k8s.namespace.name": pod_namespace,
             "k8s.pod.name": os.getenv("POD_NAME", os.getenv("HOSTNAME", "")),
             "host.id": all_metadata["instance"]["id"],
-            "container.name": container_name,
             "gcp.resource_type": "gke_container",
         }
     )

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/__init__.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/__init__.py
@@ -62,6 +62,9 @@ def get_gce_resources():
 def get_gke_resources():
     """Resource finder for GKE attributes"""
 
+    if os.getenv("KUBERNETES_SERVICE_HOST") is None:
+        return {}
+
     (
         common_attributes,
         all_metadata,

--- a/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
@@ -86,6 +86,7 @@ class TestGKEResourceFinder(unittest.TestCase):
     def tearDown(self) -> None:
         clear_gke_env_vars()
 
+    # pylint: disable=unused-argument
     def test_not_running_on_gke(self, getter):
         pop_environ_key(KUBERNETES_SERVICE_HOST)
         found_resources = get_gke_resources()
@@ -107,7 +108,7 @@ class TestGKEResourceFinder(unittest.TestCase):
                 "cloud.zone": "zone",
                 "cloud.provider": "gcp",
                 "gcp.resource_type": "gke_container",
-            }
+            },
         )
 
     # pylint: disable=unused-argument

--- a/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_gcp_resource_detector.py
@@ -88,7 +88,20 @@ class TestGKEResourceFinder(unittest.TestCase):
     # pylint: disable=unused-argument
     def test_missing_container_name(self, getter):
         pop_environ_key(CONTAINER_NAME)
-        self.assertEqual(get_gke_resources(), {})
+        found_resources = get_gke_resources()
+        self.assertEqual(
+            found_resources,
+            {
+                "cloud.account.id": "project_id",
+                "k8s.cluster.name": "cluster_name",
+                "k8s.namespace.name": "",
+                "host.id": "instance_id",
+                "k8s.pod.name": "",
+                "cloud.zone": "zone",
+                "cloud.provider": "gcp",
+                "gcp.resource_type": "gke_container",
+            }
+        )
 
     # pylint: disable=unused-argument
     def test_environment_empty_strings(self, getter):


### PR DESCRIPTION
- If the env `CONTAINER_NAME` is not found, it is not set, instead of silently disabling the resource detector all together.
- This makes the behavior consistent with https://github.com/GoogleCloudPlatform/opentelemetry-operations-go.