### PR TITLE
Create a Readonly Propagator to match the golang "One Way" propagator.

### DIFF
--- a/opentelemetry-propagator-gcp/README.rst
+++ b/opentelemetry-propagator-gcp/README.rst
@@ -18,8 +18,51 @@ Installation
 
     pip install opentelemetry-propagator-gcp
 
-..
-    TODO: Add usage info here
+Usage
+-----
+
+The ``CloudTraceReadonlyPropagator`` reads the Google Cloud
+``X-Cloud-Trace-Context`` format, but does not write the
+``X-Cloud-Trace-Context`` header on outgoing requests. It is intended for use
+with a CompositePropagator as below.
+
+.. code-block:: python
+
+    from opentelemetry.propagate import set_global_textmap
+    from opentelemetry.propagators.composite import CompositePropagator
+    from opentelemetry.propagators.cloud_trace_propagator import (
+        CloudTraceReadonlyPropagator,
+    )
+    set_global_textmap(CompositePropagator([
+        CloudTraceReadonlyPropagator(),
+        propagate.get_global_textmap()
+    ]
+    ))
+
+The ``CloudTraceFormatPropagator`` reads and writes the
+``X-Cloud-Trace-Context`` header formats. Note that when using this propagator,
+the ``sampled`` bit is interpreted as the ``TRACE_TRUE`` flag, which may cause a
+higher sampling rate than desired. See the `Trace documentation
+<https://cloud.google.com/trace/docs/setup#force-trace>` for additional context.
+
+.. code-block:: python
+
+    from opentelemetry.propagate import set_global_textmap
+    from opentelemetry.propagators.cloud_trace_propagator import (
+        CloudTraceFormatPropagator,
+    )
+
+    # Set the X-Cloud-Trace-Context header
+    set_global_textmap(CloudTraceFormatPropagator())
+.. code-block:: python
+
+    from opentelemetry.propagate import set_global_textmap
+    from opentelemetry.propagators.cloud_trace_propagator import (
+        CloudTraceFormatPropagator,
+    )
+
+    # Set the X-Cloud-Trace-Context header
+    set_global_textmap(CloudTraceFormatPropagator())
 
 
 References

--- a/opentelemetry-propagator-gcp/README.rst
+++ b/opentelemetry-propagator-gcp/README.rst
@@ -33,11 +33,12 @@ with a CompositePropagator as below.
     from opentelemetry.propagators.cloud_trace_propagator import (
         CloudTraceOneWayPropagator,
     )
-    set_global_textmap(CompositePropagator([
-        CloudTraceOneWayPropagator(),
-        propagate.get_global_textmap()
-    ]
-    ))
+    set_global_textmap(
+        CompositePropagator([
+            CloudTraceOneWayPropagator(),
+            propagate.get_global_textmap(),
+        ]),
+    )
 
 The ``CloudTraceFormatPropagator`` reads and writes the
 ``X-Cloud-Trace-Context`` header formats. Note that when using this propagator,

--- a/opentelemetry-propagator-gcp/README.rst
+++ b/opentelemetry-propagator-gcp/README.rst
@@ -21,7 +21,7 @@ Installation
 Usage
 -----
 
-The ``CloudTraceReadonlyPropagator`` reads the Google Cloud
+The ``CloudTraceOneWayPropagator`` reads the Google Cloud
 ``X-Cloud-Trace-Context`` format, but does not write the
 ``X-Cloud-Trace-Context`` header on outgoing requests. It is intended for use
 with a CompositePropagator as below.
@@ -31,10 +31,10 @@ with a CompositePropagator as below.
     from opentelemetry.propagate import set_global_textmap
     from opentelemetry.propagators.composite import CompositePropagator
     from opentelemetry.propagators.cloud_trace_propagator import (
-        CloudTraceReadonlyPropagator,
+        CloudTraceOneWayPropagator,
     )
     set_global_textmap(CompositePropagator([
-        CloudTraceReadonlyPropagator(),
+        CloudTraceOneWayPropagator(),
         propagate.get_global_textmap()
     ]
     ))

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
@@ -138,3 +138,20 @@ class CloudTraceFormatPropagator(textmap.TextMapPropagator):
     @property
     def fields(self) -> typing.Set[str]:
         return _FIELDS
+
+class CloudTraceReadonlyPropagator(CloudTraceFormatPropagator):
+    """This class extracts Trace Context in the Google Cloud format, but does
+    not inject this header. It is intended for use in a Composite Propagator to
+    inject context in a different format than was received.
+    """
+    def inject(
+        self,
+        carrier: textmap.CarrierT,
+        context: typing.Optional[Context] = None,
+        setter: textmap.Setter = textmap.default_setter,
+    ) -> None:
+        return
+
+    @property
+    def fields(self) -> typing.Set[str]:
+        return []

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
@@ -139,11 +139,13 @@ class CloudTraceFormatPropagator(textmap.TextMapPropagator):
     def fields(self) -> typing.Set[str]:
         return _FIELDS
 
+
 class CloudTraceReadonlyPropagator(CloudTraceFormatPropagator):
     """This class extracts Trace Context in the Google Cloud format, but does
     not inject this header. It is intended for use in a Composite Propagator to
     inject context in a different format than was received.
     """
+
     def inject(
         self,
         carrier: textmap.CarrierT,

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/__init__.py
@@ -140,7 +140,7 @@ class CloudTraceFormatPropagator(textmap.TextMapPropagator):
         return _FIELDS
 
 
-class CloudTraceReadonlyPropagator(CloudTraceFormatPropagator):
+class CloudTraceOneWayPropagator(CloudTraceFormatPropagator):
     """This class extracts Trace Context in the Google Cloud format, but does
     not inject this header. It is intended for use in a Composite Propagator to
     inject context in a different format than was received.
@@ -156,4 +156,4 @@ class CloudTraceReadonlyPropagator(CloudTraceFormatPropagator):
 
     @property
     def fields(self) -> typing.Set[str]:
-        return []
+        return set()


### PR DESCRIPTION
Also adds usage information to README.rst for both propagators.