### PR TITLE
fix auto-instrument loading tests for trace exporter.

### DIFF
--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -30,6 +30,7 @@ steps:
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
+      - --health-check-timeout=5m
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:

--- a/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_auto_instrument.py
+++ b/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_auto_instrument.py
@@ -24,8 +24,10 @@ class TestCloudTraceAutoInstrument(TestCase):
     def test_loads_cloud_trace_exporter(self):
         """Test that OTel configuration internals can load the trace exporter from entrypoint
         by name"""
-        trace_exporters, _ = _import_exporters(
-            trace_exporter_names=["gcp_trace"], log_exporter_names=[]
+        trace_exporters, _, _ = _import_exporters(
+            trace_exporter_names=["gcp_trace"],
+            log_exporter_names=[],
+            metric_exporter_names=[],
         )
         self.assertEqual(
             trace_exporters, {"gcp_trace": CloudTraceSpanExporter}


### PR DESCRIPTION
call to `_import_exporters()` is missing a positional arg, as reported by [this failing PR test](https://app.circleci.com/pipelines/github/GoogleCloudPlatform/opentelemetry-operations-python/731/workflows/8cc32f9e-88f5-4e1e-bc2f-66f8c52a8736/jobs/4816) also verified locally on a clean checkout.