### PR TITLE
Update gce build to have a higher health check timeout

### DIFF
--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -30,6 +30,7 @@ steps:
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
+      - --health-check-timeout=5m
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 substitutions:


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/197#issuecomment-1248536459