### PR TITLE
Drop support for Python 3.6, add 3.10 and 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   # in tox.ini
   dev_python:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.10
 
 commands:
   run_with_pip_cache:
@@ -50,7 +50,7 @@ commands:
     description: Checkout code and install tox
     steps:
       - checkout
-      - run: sudo pip install tox-factor
+      - run: pip install tox-factor
 
 jobs:
   lint:
@@ -58,7 +58,7 @@ jobs:
     steps:
       - setup
       - run_with_pip_cache:
-          cache_key_base: lint-python3.9
+          cache_key_base: lint-python3.10
           steps:
             - run: tox -s false -f lint-ci
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - setup
       - run_with_pip_cache:
-          cache_key_base: lint-python3.9
+          cache_key_base: lint-python3.10
           steps:
             - run: tox -s false -f docs-ci
       - run:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - setup
       - run_with_pip_cache:
-          cache_key_base: mypy-python3.9
+          cache_key_base: mypy-python3.10
           steps:
             - run: tox -s false -f mypy-ci
       - store_test_results_command
@@ -95,7 +95,7 @@ jobs:
         type: integer
         description: The x in python3.x
     docker:
-      - image: circleci/python:3.<< parameters.python3_minor >>
+      - image: cimg/python:3.<< parameters.python3_minor >>
     steps:
       - setup
       - run_with_pip_cache:
@@ -120,4 +120,4 @@ workflows:
           name: tests-python3.<< matrix.python3_minor >>
           matrix:
             parameters:
-              python3_minor: [6, 7, 8, 9]
+              python3_minor: [7, 8, 9, 10, 11]

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -14,13 +14,14 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-exporter-gcp-trace/setup.cfg
+++ b/opentelemetry-exporter-gcp-trace/setup.cfg
@@ -14,13 +14,14 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-propagator-gcp/setup.cfg
+++ b/opentelemetry-propagator-gcp/setup.cfg
@@ -14,13 +14,14 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-resourcedetector-gcp/setup.cfg
+++ b/opentelemetry-resourcedetector-gcp/setup.cfg
@@ -14,13 +14,14 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir=
     =src
 packages=find_namespace:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 skip_missing_interpreters = True
 envlist =
   ; Add the `ci` factor to any env that should be running during CI.
-  py3{6,7,8,9}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
+  py3{7,8,9,10,11}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   {lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   docs-ci
 
@@ -21,7 +21,7 @@ base_deps =
   -c {toxinidir}/dev-constraints.txt
   -e {toxinidir}/test-common
 
-dev_basepython = python3.9
+dev_basepython = python3.10
 dev_deps =
   {[constants]base_deps}
   black
@@ -45,7 +45,7 @@ setenv =
   propagator: PACKAGE_NAME = opentelemetry-propagator-gcp
   resourcedetector: PACKAGE_NAME = opentelemetry-resourcedetector-gcp
 
-[testenv:py3{6,7,8,9}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
+[testenv:py3{7,8,9,10,11}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 deps =
   test: {[constants]base_deps}
   test: pytest


### PR DESCRIPTION
This follows the supported versions in upstream OTel python.
