### PR TITLE
Drop python3.11 temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,4 +120,4 @@ workflows:
           name: tests-python3.<< matrix.python3_minor >>
           matrix:
             parameters:
-              python3_minor: [7, 8, 9, 10, 11]
+              python3_minor: [7, 8, 9, 10]

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
 
 [options]
 python_requires = >=3.7

--- a/opentelemetry-exporter-gcp-trace/setup.cfg
+++ b/opentelemetry-exporter-gcp-trace/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
 
 [options]
 python_requires = >=3.7

--- a/opentelemetry-propagator-gcp/setup.cfg
+++ b/opentelemetry-propagator-gcp/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
 
 [options]
 python_requires = >=3.7

--- a/opentelemetry-resourcedetector-gcp/setup.cfg
+++ b/opentelemetry-resourcedetector-gcp/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
 
 [options]
 python_requires = >=3.7

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 skip_missing_interpreters = True
 envlist =
   ; Add the `ci` factor to any env that should be running during CI.
-  py3{7,8,9,10,11}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
+  py3{7,8,9,10}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   {lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   docs-ci
 
@@ -45,7 +45,7 @@ setenv =
   propagator: PACKAGE_NAME = opentelemetry-propagator-gcp
   resourcedetector: PACKAGE_NAME = opentelemetry-resourcedetector-gcp
 
-[testenv:py3{7,8,9,10,11}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
+[testenv:py3{7,8,9,10}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 deps =
   test: {[constants]base_deps}
   test: pytest


### PR DESCRIPTION
Until https://github.com/googleapis/proto-plus-python/issues/326 is fixed, client libraries don't properly support 3.11 