### PR TITLE
Add snapshot test setup code and basic tests

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -5,6 +5,7 @@ mypy-extensions==0.4.3
 mypy==0.982
 pylint==2.8.3
 Sphinx==4.3.1
+syrupy==3.0.4
 types-protobuf==3.20.4.2
 types-requests==2.28.11.2
 types-setuptools==65.5.0.2

--- a/opentelemetry-exporter-gcp-monitoring/tests/__snapshots__/test_cloud_monitoring/test_counter.json
+++ b/opentelemetry-exporter-gcp-monitoring/tests/__snapshots__/test_cloud_monitoring/test_counter.json
@@ -1,0 +1,62 @@
+{
+  "/google.monitoring.v3.MetricService/CreateMetricDescriptor": [
+    {
+      "metricDescriptor": {
+        "description": "foo",
+        "displayName": "mycounter",
+        "labels": [
+          {
+            "key": "string"
+          },
+          {
+            "key": "int"
+          },
+          {
+            "key": "float"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "type": "workload.googleapis.com/mycounter",
+        "valueType": "INT64"
+      },
+      "name": "projects/fakeproject"
+    }
+  ],
+  "/google.monitoring.v3.MetricService/CreateTimeSeries": [
+    {
+      "name": "projects/fakeproject",
+      "timeSeries": [
+        {
+          "metric": {
+            "labels": {
+              "float": "123.4",
+              "int": "123",
+              "string": "string"
+            },
+            "type": "workload.googleapis.com/mycounter"
+          },
+          "metricKind": "CUMULATIVE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "str",
+                "startTime": "str"
+              },
+              "value": {
+                "int64Value": "123"
+              }
+            }
+          ],
+          "resource": {
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            },
+            "type": "generic_node"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/opentelemetry-exporter-gcp-monitoring/tests/conftest.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/conftest.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=unused-import
+
+# import fixtures to be made available to other tests
+from fixtures.gcmfake import fixture_gcmfake
+from fixtures.snapshot_gcmcalls import fixture_snapshot_gcmcalls

--- a/opentelemetry-exporter-gcp-monitoring/tests/fixtures/gcmfake.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/fixtures/gcmfake.py
@@ -1,0 +1,136 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Mapping, Tuple
+
+import grpc
+import pytest
+from google.api.metric_pb2 import MetricDescriptor
+from google.cloud.monitoring_v3 import (
+    CreateMetricDescriptorRequest,
+    CreateTimeSeriesRequest,
+    MetricServiceClient,
+)
+from google.cloud.monitoring_v3.services.metric_service.transports import (
+    MetricServiceGrpcTransport,
+)
+
+# pylint: disable=no-name-in-module
+from google.protobuf.empty_pb2 import Empty
+from google.protobuf.message import Message
+from grpc import (
+    GenericRpcHandler,
+    RpcContext,
+    RpcMethodHandler,
+    insecure_channel,
+    method_handlers_generic_handler,
+    unary_unary_rpc_method_handler,
+)
+
+# Mapping of fully qualified GCM API method names to list of requests received
+GcmCalls = Mapping[str, List[Message]]
+
+
+class FakeHandler(GenericRpcHandler):
+    """gRPC handler partially implementing the GCM API and capturing the requests.
+
+    Captures the request protos made to each method.
+    """
+
+    _service = "google.monitoring.v3.MetricService"
+
+    def __init__(self):
+        # pylint: disable=no-member
+        super().__init__()
+        self._calls: GcmCalls = defaultdict(list)
+
+        self._wrapped = method_handlers_generic_handler(
+            self._service,
+            dict(
+                [
+                    self._make_impl(
+                        "CreateTimeSeries",
+                        lambda req, ctx: Empty(),
+                        CreateTimeSeriesRequest.deserialize,
+                        Empty.SerializeToString,
+                    ),
+                    self._make_impl(
+                        "CreateMetricDescriptor",
+                        # return the metric descriptor back
+                        lambda req, ctx: req.metric_descriptor,
+                        CreateMetricDescriptorRequest.deserialize,
+                        MetricDescriptor.SerializeToString,
+                    ),
+                ]
+            ),
+        )
+
+    def _make_impl(
+        self,
+        method: str,
+        behavior: Callable[[Message, RpcContext], Message],
+        deserializer,
+        serializer,
+    ) -> Tuple[str, RpcMethodHandler]:
+        def impl(req: Message, context: RpcContext) -> Message:
+            self._calls[f"/{self._service}/{method}"].append(req)
+            return behavior(req, context)
+
+        return method, unary_unary_rpc_method_handler(
+            impl,
+            request_deserializer=deserializer,
+            response_serializer=serializer,
+        )
+
+    def service(self, handler_call_details):
+        res = self._wrapped.service(handler_call_details)
+        return res
+
+    def get_calls(self) -> GcmCalls:
+        """Returns calls made to each GCM API method"""
+        return self._calls
+
+
+@dataclass
+class GcmFake:
+    client: MetricServiceClient
+    get_calls: Callable[[], GcmCalls]
+
+
+@pytest.fixture(name="gcmfake")
+def fixture_gcmfake() -> Iterable[GcmFake]:
+    """Fixture providing faked GCM api with captured requests"""
+
+    handler = FakeHandler()
+    server = None
+
+    try:
+        # Run in a single thread to serialize requests
+        with ThreadPoolExecutor(1) as executor:
+            server = grpc.server(executor, handlers=[handler])
+            port = server.add_insecure_port("localhost:0")
+            server.start()
+            with insecure_channel(f"localhost:{port}") as channel:
+                yield GcmFake(
+                    client=MetricServiceClient(
+                        transport=MetricServiceGrpcTransport(channel=channel),
+                    ),
+                    get_calls=handler.get_calls,
+                )
+    finally:
+        if server:
+            server.stop(None)

--- a/opentelemetry-exporter-gcp-monitoring/tests/fixtures/snapshot_gcmcalls.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/fixtures/snapshot_gcmcalls.py
@@ -1,0 +1,77 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, cast
+
+import google.protobuf.message
+import proto
+import pytest
+from fixtures.gcmfake import GcmCalls
+from google.protobuf import json_format
+from syrupy.extensions.json import JSONSnapshotExtension
+from syrupy.matchers import path_type
+from syrupy.types import (
+    PropertyFilter,
+    PropertyMatcher,
+    SerializableData,
+    SerializedData,
+)
+
+
+# pylint: disable=too-many-ancestors
+class GcmCallsSnapshotExtension(JSONSnapshotExtension):
+    """syrupy extension to serialize GcmCalls.
+
+    Serializes the protobufs for each method call into JSON for storing as a snapshot.
+    """
+
+    def serialize(
+        self,
+        data: SerializableData,
+        *,
+        exclude: Optional[PropertyFilter] = None,
+        matcher: Optional[PropertyMatcher] = None,
+    ) -> SerializedData:
+        calls = cast(GcmCalls, data)
+        json = {}
+        for method, requests in calls.items():
+            dict_requests = []
+            for request in requests:
+                if isinstance(request, proto.message.Message):
+                    request = type(request).pb(request)
+                elif isinstance(request, google.protobuf.message.Message):
+                    pass
+                else:
+                    raise ValueError(
+                        f"Excepted a proto-plus or protobuf message, got {type(request)}"
+                    )
+                dict_requests.append(json_format.MessageToDict(request))
+            json[method] = dict_requests
+
+        return super().serialize(json, exclude=exclude, matcher=matcher)
+
+
+@pytest.fixture(name="snapshot_gcmcalls")
+def fixture_snapshot_gcmcalls(snapshot):
+    """Fixture for snapshot testing of GcmCalls
+
+    TimeInterval.start_time and TimeInterval.end_time timestamps are "redacted" since they are
+    dynamic depending on when the test is run.
+    """
+    return snapshot.use_extension(GcmCallsSnapshotExtension)(
+        matcher=path_type(
+            {r".*\.interval\.(start|end)Time": (str,)},
+            regex=True,
+        )
+    )

--- a/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
@@ -13,15 +13,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Some tests in this file use [syrupy](https://github.com/tophat/syrupy) for snapshot testing aka
+golden testing. The GCM API calls are captured with a gRPC fake and compared to the existing
+snapshot file in the __snapshots__ directory.
+
+If an expected behavior change is made to the exporter causing these tests to fail, regenerate
+the snapshots by running tox to pass the --snapshot-update flag to pytest:
+
+```sh
+tox -e py310-ci-test-cloudmonitoring -- --snapshot-update
+```
+
+Be sure to review the changes.
+"""
+
+from typing import Iterable
+
+import pytest
+from fixtures.gcmfake import GcmFake
 from google.auth.credentials import AnonymousCredentials
 from google.cloud.monitoring_v3 import MetricServiceClient
 from opentelemetry.exporter.cloud_monitoring import (
     CloudMonitoringMetricsExporter,
 )
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.util.types import Attributes
 
 PROJECT_ID = "fakeproject"
+LABELS: Attributes = {
+    "string": "string",
+    "int": 123,
+    "float": 123.4,
+}
+
+
+@pytest.fixture(name="meter_provider")
+def fixture_meter_provider(gcmfake: GcmFake) -> Iterable[MeterProvider]:
+    mp = MeterProvider(
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                CloudMonitoringMetricsExporter(
+                    project_id=PROJECT_ID, client=gcmfake.client
+                )
+            )
+        ],
+        shutdown_on_exit=False,
+    )
+    yield mp
+    mp.shutdown()
 
 
 def test_create_monitoring_exporter() -> None:
     client = MetricServiceClient(credentials=AnonymousCredentials())
     CloudMonitoringMetricsExporter(project_id=PROJECT_ID, client=client)
+
+
+def test_counter(
+    meter_provider: MeterProvider,
+    gcmfake: GcmFake,
+    snapshot_gcmcalls,
+) -> None:
+    counter = meter_provider.get_meter(__name__).create_counter(
+        "mycounter", description="foo", unit="{myunit}"
+    )
+    counter.add(123, LABELS)
+    meter_provider.force_flush()
+    assert gcmfake.get_calls() == snapshot_gcmcalls

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ dev_deps =
   mypy
   pylint
   pytest
+  syrupy
   types-protobuf
   types-requests
   types-setuptools
@@ -50,6 +51,7 @@ setenv =
 deps =
   test: {[constants]base_deps}
   test: pytest
+  test: syrupy
 passenv = SKIP_GET_MOCK_SERVER
 changedir = {env:PACKAGE_NAME}
 


### PR DESCRIPTION
This is very similar to what we've done for the collector integration tests in https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/main/exporter/collector/integrationtest/testdata/fixtures/metrics

Implemented one basic test with a counter. I will add more tests in the next PR