### PR TITLE
Remove todo comment that is no longer applicable

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -326,8 +326,6 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                         )
                         series = TimeSeries(
                             resource=monitored_resource,
-                            # TODO: remove
-                            # https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/84
                             metric_kind=descriptor.metric_kind,
                             points=[point],
                             metric=GMetric(


### PR DESCRIPTION
There's no need to stop sending MetricKind, as we actually do that in
the [collector](https://cs.github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/e955c204f4f2bfdc92ff0ad52786232b975efcc2/exporter/metric/metric.go?q=createtimeseries#L479).
I don't think it's worth keeping a todo around.