### PR TITLE
Normalize invalid label keys

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -169,7 +169,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                 if key in seen_keys:
                     continue
                 seen_keys.add(key)
-                descriptor["labels"].append(LabelDescriptor(key=key))  # type: ignore[union-attr] # TODO #56
+                descriptor["labels"].append(LabelDescriptor(key=_normalize_label_key(key)))  # type: ignore[union-attr] # TODO #56
 
         if self.unique_identifier:
             descriptor["labels"].append(  # type: ignore[union-attr] # TODO #56
@@ -312,7 +312,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
 
                     for data_point in metric.data.data_points:
                         labels = {
-                            key: str(value)
+                            _normalize_label_key(key): str(value)
                             for key, value in (
                                 data_point.attributes or {}
                             ).items()
@@ -357,3 +357,17 @@ def _timestamp_from_nanos(nanos: int) -> Timestamp:
     ts = Timestamp()
     ts.FromNanoseconds(nanos)
     return ts
+
+
+def _normalize_label_key(key: str) -> str:
+    """Makes the key into a valid GCM label key
+
+    See reference impl
+    https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/e955c204f4f2bfdc92ff0ad52786232b975efcc2/exporter/metric/metric.go#L595-L604
+    """
+    sanitized = "".join(
+        c if c.isalpha() or c.isnumeric() else "_" for c in key
+    )
+    if sanitized[0].isdigit():
+        sanitized = "key_" + sanitized
+    return sanitized

--- a/opentelemetry-exporter-gcp-monitoring/tests/__snapshots__/test_cloud_monitoring/test_invalid_label_keys.json
+++ b/opentelemetry-exporter-gcp-monitoring/tests/__snapshots__/test_cloud_monitoring/test_invalid_label_keys.json
@@ -1,0 +1,54 @@
+{
+  "/google.monitoring.v3.MetricService/CreateMetricDescriptor": [
+    {
+      "metricDescriptor": {
+        "description": "foo",
+        "displayName": "mycounter",
+        "labels": [
+          {
+            "key": "key_1some_invalid__key"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "type": "workload.googleapis.com/mycounter",
+        "valueType": "INT64"
+      },
+      "name": "projects/fakeproject"
+    }
+  ],
+  "/google.monitoring.v3.MetricService/CreateTimeSeries": [
+    {
+      "name": "projects/fakeproject",
+      "timeSeries": [
+        {
+          "metric": {
+            "labels": {
+              "key_1some_invalid__key": "value"
+            },
+            "type": "workload.googleapis.com/mycounter"
+          },
+          "metricKind": "CUMULATIVE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "str",
+                "startTime": "str"
+              },
+              "value": {
+                "int64Value": "12"
+              }
+            }
+          ],
+          "resource": {
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            },
+            "type": "generic_node"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
@@ -201,3 +201,17 @@ def test_observable_gauge(
     )
     meter_provider.force_flush()
     assert gcmfake.get_calls() == snapshot_gcmcalls
+
+
+def test_invalid_label_keys(
+    gcmfake_meter_provider: GcmFakeMeterProvider,
+    gcmfake: GcmFake,
+    snapshot_gcmcalls,
+) -> None:
+    meter_provider = gcmfake_meter_provider()
+    counter = meter_provider.get_meter(__name__).create_counter(
+        "mycounter", description="foo", unit="{myunit}"
+    )
+    counter.add(12, {"1some.invalid$\\key": "value"})
+    meter_provider.force_flush()
+    assert gcmfake.get_calls() == snapshot_gcmcalls

--- a/opentelemetry-exporter-gcp-monitoring/tests/test_normalize_label_key.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/test_normalize_label_key.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from opentelemetry.exporter.cloud_monitoring import _normalize_label_key
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("valid_key_1", "valid_key_1"),
+        ("hellø", "hellø"),
+        ("123", "key_123"),
+        ("key!321", "key_321"),
+        ("key!321", "key_321"),
+        ("hyphens-dots.slashes/", "hyphens_dots_slashes_"),
+        ("non_letters_:£¢$∞", "non_letters______"),
+    ],
+)
+def test_normalize_label_key(key: str, expected: str) -> None:
+    assert _normalize_label_key(key) == expected


### PR DESCRIPTION
Implementation copied from the Go exporter https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/e955c204f4f2bfdc92ff0ad52786232b975efcc2/exporter/metric/metric.go#L595-L604
