### PR TITLE
Add spec compliant GCE detection

### DIFF
--- a/opentelemetry-resourcedetector-gcp/CHANGELOG.md
+++ b/opentelemetry-resourcedetector-gcp/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add spec compliant GCE detection
+  ([#231])(https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/231)
+
 ## Version 1.4.0a0
 
 Released 2022-12-05

--- a/opentelemetry-resourcedetector-gcp/CHANGELOG.md
+++ b/opentelemetry-resourcedetector-gcp/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add spec compliant GCE detection
-  ([#231])(https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/231)
+  ([#231](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/231))
 
 ## Version 1.4.0a0
 

--- a/opentelemetry-resourcedetector-gcp/setup.cfg
+++ b/opentelemetry-resourcedetector-gcp/setup.cfg
@@ -28,6 +28,8 @@ install_requires =
     opentelemetry-api ~= 1.0
     opentelemetry-sdk ~= 1.0
     requests ~= 2.24
+    # TODO: remove when Python 3.7 is dropped
+    typing_extensions ~= 4.0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_detector.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_detector.py
@@ -1,0 +1,84 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Mapping
+
+from opentelemetry.resourcedetector.gcp_resource_detector import (
+    _gce,
+    _metadata,
+)
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+from opentelemetry.util.types import AttributeValue
+
+
+# TODO: use opentelemetry-semantic-conventions package for these constants once it has
+# stabilized. Right now, pinning an unstable version would cause dependency conflicts for
+# users so these are copied in.
+class ResourceAttributes:
+    AWS_EC2 = "aws_ec2"
+    CLOUD_ACCOUNT_ID = "cloud.account.id"
+    CLOUD_AVAILABILITY_ZONE = "cloud.availability_zone"
+    CLOUD_PLATFORM_KEY = "cloud.platform"
+    CLOUD_PROVIDER = "cloud.provider"
+    CLOUD_REGION = "cloud.region"
+    GCP_COMPUTE_ENGINE = "gcp_compute_engine"
+    GCP_KUBERNETES_ENGINE = "gcp_kubernetes_engine"
+    HOST_ID = "host.id"
+    HOST_NAME = "host.name"
+    HOST_TYPE = "host.type"
+    K8S_CLUSTER_NAME = "k8s.cluster.name"
+    K8S_CONTAINER_NAME = "k8s.container.name"
+    K8S_NAMESPACE_NAME = "k8s.namespace.name"
+    K8S_NODE_NAME = "k8s.node.name"
+    K8S_POD_NAME = "k8s.pod.name"
+    SERVICE_INSTANCE_ID = "service.instance.id"
+    SERVICE_NAME = "service.name"
+    SERVICE_NAMESPACE = "service.namespace"
+
+
+class GoogleCloudResourceDetector(ResourceDetector):
+    def detect(self) -> Resource:
+        if not _metadata.is_available():
+            return Resource.get_empty()
+
+        if _gce.on_gce():
+            return _gce_resource()
+
+        return Resource.get_empty()
+
+
+def _gce_resource() -> Resource:
+    zone_and_region = _gce.availability_zone_and_region()
+    return _make_resource(
+        {
+            ResourceAttributes.CLOUD_PLATFORM_KEY: ResourceAttributes.GCP_COMPUTE_ENGINE,
+            ResourceAttributes.CLOUD_AVAILABILITY_ZONE: zone_and_region.zone,
+            ResourceAttributes.CLOUD_REGION: zone_and_region.region,
+            ResourceAttributes.HOST_TYPE: _gce.host_type(),
+            ResourceAttributes.HOST_ID: _gce.host_id(),
+            ResourceAttributes.HOST_NAME: _gce.host_name(),
+        }
+    )
+
+
+def _make_resource(attrs: Mapping[str, AttributeValue]) -> Resource:
+    return Resource.create(
+        {
+            ResourceAttributes.CLOUD_PROVIDER: "gcp",
+            ResourceAttributes.CLOUD_ACCOUNT_ID: _metadata.get_metadata()[
+                "project"
+            ]["projectId"],
+            **attrs,
+        }
+    )

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_gce.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_gce.py
@@ -52,7 +52,7 @@ def host_id() -> str:
 
 
 def host_name() -> str:
-    return get_metadata()["instance"]["hostname"]
+    return get_metadata()["instance"]["name"]
 
 
 @dataclass

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_gce.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_gce.py
@@ -1,0 +1,75 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+from dataclasses import dataclass
+
+from opentelemetry.resourcedetector.gcp_resource_detector._metadata import (
+    MetadataAccessException,
+    get_metadata,
+)
+
+# Format described in
+# https://cloud.google.com/compute/docs/metadata/default-metadata-values#vm_instance_metadata
+_ZONE_REGION_RE = re.compile(
+    r"projects\/\d+\/zones\/(?P<zone>(?P<region>\w+-\w+)-\w+)"
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def on_gce() -> bool:
+    try:
+        get_metadata()["instance"]["machineType"]
+    except (MetadataAccessException, KeyError):
+        _logger.debug(
+            "Could not fetch metadata attribute instance/machineType, "
+            "assuming not on GCE.",
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def host_type() -> str:
+    return get_metadata()["instance"]["machineType"]
+
+
+def host_id() -> str:
+    return get_metadata()["instance"]["id"]
+
+
+def host_name() -> str:
+    return get_metadata()["instance"]["hostname"]
+
+
+@dataclass
+class ZoneAndRegion:
+    zone: str
+    region: str
+
+
+def availability_zone_and_region() -> ZoneAndRegion:
+    full_zone = get_metadata()["instance"]["zone"]
+    match = _ZONE_REGION_RE.search(full_zone)
+    if not match:
+        raise Exception(
+            "zone was not in the expected format: "
+            f"projects/PROJECT_NUM/zones/COUNTRY-REGION-ZONE. Got {full_zone}"
+        )
+
+    return ZoneAndRegion(
+        zone=match.group("zone"), region=match.group("region")
+    )

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_metadata.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_metadata.py
@@ -1,0 +1,85 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from functools import lru_cache
+
+import requests
+
+# TODO: remove when Python 3.7 is dropped
+from typing_extensions import TypedDict
+
+_GCP_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/"
+_INSTANCE = "instance"
+_RECURSIVE_PARAMS = {"recursive": "true"}
+_GCP_METADATA_URL_HEADER = {"Metadata-Flavor": "Google"}
+_TIMEOUT_SEC = 5
+
+_logger = logging.getLogger(__name__)
+
+
+class Project(TypedDict):
+    projectId: str
+
+
+class Instance(TypedDict):
+    hostname: str
+    id: str
+    machineType: str
+    zone: str
+
+
+class Metadata(TypedDict):
+    project: Project
+    instance: Instance
+
+
+class MetadataAccessException(Exception):
+    pass
+
+
+@lru_cache(maxsize=None)
+def get_metadata() -> Metadata:
+    """Get all instance and project metadata from the metadata server
+
+    Cached for the lifetime of the process.
+    """
+    try:
+        all_metadata = requests.get(
+            f"{_GCP_METADATA_URL}",
+            params=_RECURSIVE_PARAMS,
+            headers=_GCP_METADATA_URL_HEADER,
+            timeout=_TIMEOUT_SEC,
+        ).json()
+    except requests.RequestException as err:
+        raise MetadataAccessException() from err
+
+    return all_metadata
+
+
+@lru_cache(maxsize=None)
+def is_available() -> bool:
+    try:
+        requests.get(
+            f"{_GCP_METADATA_URL}{_INSTANCE}/",
+            headers=_GCP_METADATA_URL_HEADER,
+            timeout=_TIMEOUT_SEC,
+        ).raise_for_status()
+    except requests.RequestException:
+        _logger.debug(
+            "Failed to make request to metadata server, assuming it's not available",
+            exc_info=True,
+        )
+        return False
+    return True

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_metadata.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_metadata.py
@@ -34,15 +34,15 @@ class Project(TypedDict):
 
 
 class Instance(TypedDict):
-    hostname: str
     id: str
     machineType: str
+    name: str
     zone: str
 
 
 class Metadata(TypedDict):
-    project: Project
     instance: Instance
+    project: Project
 
 
 class MetadataAccessException(Exception):

--- a/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
+++ b/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
@@ -14,7 +14,7 @@
     'cloud.provider': 'gcp',
     'cloud.region': 'us-east4',
     'host.id': 'fakeId',
-    'host.name': 'fakeHostname',
+    'host.name': 'fakeName',
     'host.type': 'fakeMachineType',
     'service.name': 'unknown_service',
     'telemetry.sdk.language': 'python',

--- a/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
+++ b/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
@@ -1,0 +1,24 @@
+# name: test_detects_empty_as_fallback
+  dict({
+  })
+# ---
+# name: test_detects_empty_when_not_available
+  dict({
+  })
+# ---
+# name: test_detects_gce
+  dict({
+    'cloud.account.id': 'fakeProject',
+    'cloud.availability_zone': 'us-east4-b',
+    'cloud.platform': 'gcp_compute_engine',
+    'cloud.provider': 'gcp',
+    'cloud.region': 'us-east4',
+    'host.id': 'fakeId',
+    'host.name': 'fakeHostname',
+    'host.type': 'fakeMachineType',
+    'service.name': 'unknown_service',
+    'telemetry.sdk.language': 'python',
+    'telemetry.sdk.name': 'opentelemetry',
+    'telemetry.sdk.version': '1.15.0',
+  })
+# ---

--- a/opentelemetry-resourcedetector-gcp/tests/test_detector.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_detector.py
@@ -1,0 +1,68 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+from opentelemetry.resourcedetector.gcp_resource_detector import _metadata
+from opentelemetry.resourcedetector.gcp_resource_detector._detector import (
+    GoogleCloudResourceDetector,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixture_reset_cache():
+    yield
+    _metadata.get_metadata.cache_clear()
+    _metadata.is_available.cache_clear()
+
+
+@pytest.fixture(name="fake_get", autouse=True)
+def fixture_fake_get(monkeypatch: pytest.MonkeyPatch):
+    mock = Mock()
+    monkeypatch.setattr(requests, "get", mock)
+    return mock
+
+
+@pytest.fixture(name="fake_metadata", autouse=True)
+def fixture_fake_metadata(fake_get: Mock):
+    json = {"instance": {}, "project": {}}
+    fake_get().json.return_value = json
+    return json
+
+
+def test_detects_empty_when_not_available(snapshot, fake_get: Mock):
+    fake_get.side_effect = requests.HTTPError()
+    assert dict(GoogleCloudResourceDetector().detect().attributes) == snapshot
+
+
+def test_detects_empty_as_fallback(snapshot):
+    assert dict(GoogleCloudResourceDetector().detect().attributes) == snapshot
+
+
+def test_detects_gce(snapshot, fake_metadata: _metadata.Metadata):
+    fake_metadata.update(
+        {
+            "project": {"projectId": "fakeProject"},
+            "instance": {
+                "hostname": "fakeHostname",
+                "id": "fakeId",
+                "machineType": "fakeMachineType",
+                "zone": "projects/233510669999/zones/us-east4-b",
+            },
+        }
+    )
+
+    assert dict(GoogleCloudResourceDetector().detect().attributes) == snapshot

--- a/opentelemetry-resourcedetector-gcp/tests/test_detector.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_detector.py
@@ -57,7 +57,7 @@ def test_detects_gce(snapshot, fake_metadata: _metadata.Metadata):
         {
             "project": {"projectId": "fakeProject"},
             "instance": {
-                "hostname": "fakeHostname",
+                "name": "fakeName",
                 "id": "fakeId",
                 "machineType": "fakeMachineType",
                 "zone": "projects/233510669999/zones/us-east4-b",

--- a/opentelemetry-resourcedetector-gcp/tests/test_gce.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_gce.py
@@ -54,7 +54,7 @@ def test_detects_host_id(fake_get_metadata: MagicMock) -> None:
 
 
 def test_detects_host_name(fake_get_metadata: MagicMock) -> None:
-    fake_get_metadata.return_value = {"instance": {"hostname": "fake"}}
+    fake_get_metadata.return_value = {"instance": {"name": "fake"}}
     assert _gce.host_name() == "fake"
 
 

--- a/opentelemetry-resourcedetector-gcp/tests/test_gce.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_gce.py
@@ -1,0 +1,75 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry.resourcedetector.gcp_resource_detector import (
+    _gce,
+    _metadata,
+)
+
+
+@pytest.fixture(name="fake_get_metadata")
+def fixture_fake_get_metadata(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock = MagicMock()
+    monkeypatch.setattr(_gce, "get_metadata", mock)
+    return mock
+
+
+# pylint: disable=unused-argument
+def test_detects_on_gce(fake_get_metadata: MagicMock) -> None:
+    assert _gce.on_gce()
+
+
+def test_detects_not_on_gce(fake_get_metadata: MagicMock) -> None:
+    # when the metadata server is not accessible
+    fake_get_metadata.side_effect = _metadata.MetadataAccessException()
+    assert not _gce.on_gce()
+
+    # when the metadata server doesn't have the expected structure
+    fake_get_metadata.return_value = {}
+    assert not _gce.on_gce()
+
+
+def test_detects_host_type(fake_get_metadata: MagicMock) -> None:
+    fake_get_metadata.return_value = {"instance": {"machineType": "fake"}}
+    assert _gce.host_type() == "fake"
+
+
+def test_detects_host_id(fake_get_metadata: MagicMock) -> None:
+    fake_get_metadata.return_value = {"instance": {"id": "fake"}}
+    assert _gce.host_id() == "fake"
+
+
+def test_detects_host_name(fake_get_metadata: MagicMock) -> None:
+    fake_get_metadata.return_value = {"instance": {"hostname": "fake"}}
+    assert _gce.host_name() == "fake"
+
+
+def test_detects_zone_and_region(fake_get_metadata: MagicMock) -> None:
+    fake_get_metadata.return_value = {
+        "instance": {"zone": "projects/233510669999/zones/us-east4-b"}
+    }
+    zone_and_region = _gce.availability_zone_and_region()
+
+    assert zone_and_region.zone == "us-east4-b"
+    assert zone_and_region.region == "us-east4"
+
+
+def test_throws_for_invalid_zone(fake_get_metadata: MagicMock) -> None:
+    fake_get_metadata.return_value = {"instance": {"zone": ""}}
+
+    with pytest.raises(Exception, match="zone was not in the expected format"):
+        _gce.availability_zone_and_region()


### PR DESCRIPTION
Mostly just copied from the JS implementation. Note Google doesn't provide a metadata library we can use here directly like we have in Go and JS.

After I have implemented GKE detection, I will replace the existing (unstable) impl with the spec compliant one and update the trace exporter and e2e tests.