### PR TITLE
Customize metric prefix

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -100,6 +100,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         project_id: Optional[str] = None,
         client: Optional[MetricServiceClient] = None,
         add_unique_identifier: bool = False,
+        prefix: Optional[str] = None,
     ):
         # Default preferred_temporality is all CUMULATIVE so need to customize
         super().__init__()
@@ -129,6 +130,10 @@ class CloudMonitoringMetricsExporter(MetricExporter):
             self._exporter_start_time_seconds,
             self._exporter_start_time_nanos,
         ) = divmod(time_ns(), NANOS_PER_SECOND)
+        if not prefix:
+          self.prefix = f"workload.googleapis.com"
+        else:
+          self.prefix = prefix
 
     def _batch_write(self, series: List[TimeSeries]) -> None:
         """Cloud Monitoring allows writing up to 200 time series at once
@@ -159,7 +164,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         :param record:
         :return:
         """
-        descriptor_type = f"workload.googleapis.com/{metric.name}"
+        descriptor_type = f"{self.prefix}/{metric.name}"
         if descriptor_type in self._metric_descriptors:
             return self._metric_descriptors[descriptor_type]
 

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -93,6 +93,8 @@ class CloudMonitoringMetricsExporter(MetricExporter):
             must be used when there exist two (or more) exporters that may
             export to the same metric name within WRITE_INTERVAL seconds of
             each other.
+        prefix: the prefix of the metric. It is "workload.googleapis.com" by
+            default if not specified.
     """
 
     def __init__(
@@ -100,7 +102,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         project_id: Optional[str] = None,
         client: Optional[MetricServiceClient] = None,
         add_unique_identifier: bool = False,
-        prefix: Optional[str] = None,
+        prefix: Optional[str] = "workload.googleapis.com",
     ):
         # Default preferred_temporality is all CUMULATIVE so need to customize
         super().__init__()
@@ -130,10 +132,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
             self._exporter_start_time_seconds,
             self._exporter_start_time_nanos,
         ) = divmod(time_ns(), NANOS_PER_SECOND)
-        if not prefix:
-          self.prefix = f"workload.googleapis.com"
-        else:
-          self.prefix = prefix
+        self._prefix = prefix
 
     def _batch_write(self, series: List[TimeSeries]) -> None:
         """Cloud Monitoring allows writing up to 200 time series at once
@@ -164,7 +163,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         :param record:
         :return:
         """
-        descriptor_type = f"{self.prefix}/{metric.name}"
+        descriptor_type = f"{self._prefix}/{metric.name}"
         if descriptor_type in self._metric_descriptors:
             return self._metric_descriptors[descriptor_type]
 

--- a/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
+++ b/opentelemetry-exporter-gcp-monitoring/tests/test_cloud_monitoring.py
@@ -56,6 +56,11 @@ LABELS: Attributes = {
 def test_create_monitoring_exporter() -> None:
     client = MetricServiceClient(credentials=AnonymousCredentials())
     CloudMonitoringMetricsExporter(project_id=PROJECT_ID, client=client)
+    CloudMonitoringMetricsExporter(
+        project_id=PROJECT_ID,
+        client=client,
+        prefix="custom.googleapis.com",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
By default, the metric prefix is "workload.googleapis.com". This change enables users to specific their own metric prefix.