### PR TITLE
Update example setup instructions for getting GCP credentials

### DIFF
--- a/docs/examples/cloud_monitoring/README.rst
+++ b/docs/examples/cloud_monitoring/README.rst
@@ -10,7 +10,7 @@ Basic Example
 To use this exporter you first need to:
 
 * `Create a Google Cloud project <https://console.cloud.google.com/projectcreate>`_.
-* Enable `Application Default Credentials
+* Set up `Application Default Credentials
   <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
   gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
   application-default login``.

--- a/docs/examples/cloud_monitoring/README.rst
+++ b/docs/examples/cloud_monitoring/README.rst
@@ -8,9 +8,12 @@ Basic Example
 -------------
 
 To use this exporter you first need to:
-    * `Create a Google Cloud project <https://console.cloud.google.com/projectcreate>`_.
-    * Enable the Cloud Monitoring API (aka Stackdriver Monitoring API) in the project `here <https://console.cloud.google.com/apis/library?q=cloud_monitoring>`_.
-    * Enable `Default Application Credentials <https://developers.google.com/identity/protocols/application-default-credentials>`_.
+
+* `Create a Google Cloud project <https://console.cloud.google.com/projectcreate>`_.
+* Enable `Application Default Credentials
+  <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
+  gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
+  application-default login``.
 
 * Installation
 
@@ -30,9 +33,10 @@ Viewing Output
 --------------------------
 
 After running the example:
-    * Go to the `Cloud Monitoring Metrics Explorer page <https://console.cloud.google.com/monitoring/metrics-explorer>`_.
-    * In "Select a Metric" enter "workload.googleapis.com/request_counter".
-    * You can filter by labels and change the graphical output here as well.
+
+* Go to the `Cloud Monitoring Metrics Explorer page <https://console.cloud.google.com/monitoring/metrics-explorer>`_.
+* In "Select a Metric" enter "workload.googleapis.com/request_counter".
+* You can filter by labels and change the graphical output here as well.
 
 Troubleshooting
 --------------------------
@@ -42,7 +46,7 @@ Troubleshooting
 
 Currently, Cloud Monitoring allows one write every 5 seconds for any unique tuple (metric_name, metric_label_value_1, metric_label_value_2, ...). The exporter should rate limit on its own but issues arise if:
 
-    * You are restarting the server more than once every 5 seconds.
-    * You have a multiple exporters (possibly on different threads) writing to the same tuple.
+* You are restarting the server more than once every 5 seconds.
+* You have a multiple exporters (possibly on different threads) writing to the same tuple.
 
 For both cases, you can pass ``add_unique_identifier=True`` to the CloudMonitoringMetricsExporter constructor. This adds a UUID label_value, making the tuple unique again. For the first case, you can also choose to just wait longer than 5 seconds between restarts.

--- a/docs/examples/cloud_resource_detector/README.rst
+++ b/docs/examples/cloud_resource_detector/README.rst
@@ -11,7 +11,7 @@ Basic Example
 To use this feature you first need to:
 
 * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-* Enable `Application Default Credentials
+* Set up `Application Default Credentials
   <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
   gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
   application-default login``.

--- a/docs/examples/cloud_resource_detector/README.rst
+++ b/docs/examples/cloud_resource_detector/README.rst
@@ -9,12 +9,14 @@ Basic Example
 -------------
 
 To use this feature you first need to:
-    * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-    * (If you want to send resource info to Cloud Trace) Enable `Cloud Trace API <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_ (listed in the Cloud Console as Stackdriver Trace API) in the project.
-    * (If you want to send resource info to Cloud Monitoring) Enable the `Cloud Monitoring API <https://console.cloud.google.com/apis/library?q=cloud_monitoring>`_ (aka Stackdriver Monitoring API) in the project.
-    * Enable Default Application Credentials by creating setting `GOOGLE_APPLICATION_CREDENTIALS <https://cloud.google.com/docs/authentication/getting-started>`_ or by `installing gcloud sdk <https://cloud.google.com/sdk/install>`_ and calling ``gcloud auth application-default login``.
-    * Setup a Google tool like `Google Compute Engine <https://cloud.google.com/compute/docs/quickstart-linux>`_ (GCE) or `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/docs/quickstart>`_ (GKE).
-    * Run the below example in the Google tool.
+
+* Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
+* Enable `Application Default Credentials
+  <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
+  gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
+  application-default login``.
+* Setup a Google tool like `Google Compute Engine <https://cloud.google.com/compute/docs/quickstart-linux>`_ (GCE) or `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/docs/quickstart>`_ (GKE).
+* Run the below example in the Google tool.
 
 * Installation
 
@@ -40,9 +42,10 @@ Checking Output
 --------------------------
 
 After running the metrics example:
-    * Go to the `Cloud Monitoring Metrics Explorer page <https://console.cloud.google.com/monitoring/metrics-explorer>`_.
-    * In "Find resource type and metric" enter "OpenTelemetry/request_counter_with_resource".
-    * You can filter by resource info and change the graphical output here as well.
+
+* Go to the `Cloud Monitoring Metrics Explorer page <https://console.cloud.google.com/monitoring/metrics-explorer>`_.
+* In "Find resource type and metric" enter "OpenTelemetry/request_counter_with_resource".
+* You can filter by resource info and change the graphical output here as well.
 
 Or, if you ran the tracing example, you can go to `Cloud Trace overview <https://console.cloud.google.com/traces/list>`_ to see the results.
 

--- a/docs/examples/cloud_trace_exporter/README.rst
+++ b/docs/examples/cloud_trace_exporter/README.rst
@@ -8,9 +8,13 @@ Basic Example
 -------------
 
 To use this exporter you first need to:
-    * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-    * Enable Cloud Trace API (listed in the Cloud Console as Stackdriver Trace API) in the project `here <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_. If the page says "API Enabled" then you're done! No need to do anything.
-    * Enable Default Application Credentials by creating setting `GOOGLE_APPLICATION_CREDENTIALS <https://cloud.google.com/docs/authentication/getting-started>`_ or by `installing gcloud sdk <https://cloud.google.com/sdk/install>`_ and calling ``gcloud auth application-default login``.
+
+* Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
+* Enable `Application Default Credentials
+  <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
+  gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
+  application-default login``.
+
 
 * Installation
 
@@ -51,16 +55,19 @@ Troubleshooting
 
 Running basic_trace.py hangs:
 #############################
-    * Make sure you've setup Application Default Credentials. Either run ``gcloud auth application-default login`` or set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to be a path to a service account token file.
+
+* Make sure you've setup Application Default Credentials. Either run ``gcloud auth application-default login`` or set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to be a path to a service account token file.
 
 Getting error ``google.api_core.exceptions.ResourceExhausted: 429 Resource has been exhausted``:
 ################################################################################################
-    * Check that you've enabled the `Cloud Trace (Stackdriver Trace) API <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_
+
+* Check that you've enabled the `Cloud Trace (Stackdriver Trace) API <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_
 
 bash: pip: command not found:
 #############################
-    * `Install pip <https://cloud.google.com/python/setup#installing_python>`_
-    * If your machine uses python2 by default, pip will also be the python2 version. Try using ``pip3`` instead of ``pip``.
+
+* `Install pip <https://cloud.google.com/python/setup#installing_python>`_
+* If your machine uses python2 by default, pip will also be the python2 version. Try using ``pip3`` instead of ``pip``.
 
 pip install is hanging
 ######################

--- a/docs/examples/cloud_trace_exporter/README.rst
+++ b/docs/examples/cloud_trace_exporter/README.rst
@@ -10,7 +10,7 @@ Basic Example
 To use this exporter you first need to:
 
 * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-* Enable `Application Default Credentials
+* Set up `Application Default Credentials
   <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
   gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
   application-default login``.

--- a/docs/examples/cloud_trace_propagator/README.rst
+++ b/docs/examples/cloud_trace_propagator/README.rst
@@ -11,7 +11,7 @@ Basic Example
 To use this feature you first need to:
 
 * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-* Enable `Application Default Credentials
+* Set up `Application Default Credentials
   <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
   gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
   application-default login``.

--- a/docs/examples/cloud_trace_propagator/README.rst
+++ b/docs/examples/cloud_trace_propagator/README.rst
@@ -9,9 +9,13 @@ Basic Example
 -------------
 
 To use this feature you first need to:
-    * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-    * Enable Cloud Trace API (listed in the Cloud Console as Stackdriver Trace API) in the project `here <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_. If the page says "API Enabled" then you're done! No need to do anything.
-    * Enable Default Application Credentials by creating setting `GOOGLE_APPLICATION_CREDENTIALS <https://cloud.google.com/docs/authentication/getting-started>`_ or by `installing gcloud sdk <https://cloud.google.com/sdk/install>`_ and calling ``gcloud auth application-default login``.
+
+* Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
+* Enable `Application Default Credentials
+  <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
+  gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
+  application-default login``.
+
 
 * Installation
 

--- a/docs/examples/flask_e2e/README.rst
+++ b/docs/examples/flask_e2e/README.rst
@@ -9,9 +9,12 @@ script that uses ``requests`` to call the Flask app and propagate context with t
 propagator.
 
 To run this example you first need to:
-    * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-    * Enable Cloud Trace API (listed in the Cloud Console as Stackdriver Trace API) in the project `here <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_. If the page says "API Enabled" then you're done! No need to do anything.
-    * Enable Default Application Credentials by creating setting `GOOGLE_APPLICATION_CREDENTIALS <https://cloud.google.com/docs/authentication/getting-started>`_ or by `installing gcloud sdk <https://cloud.google.com/sdk/install>`_ and calling ``gcloud auth application-default login``.
+
+* Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
+* Enable `Application Default Credentials
+  <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
+  gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
+  application-default login``.
 
 It is also recommended to create a fresh virtualenv for running this example:
 

--- a/docs/examples/flask_e2e/README.rst
+++ b/docs/examples/flask_e2e/README.rst
@@ -11,7 +11,7 @@ propagator.
 To run this example you first need to:
 
 * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-* Enable `Application Default Credentials
+* Set up `Application Default Credentials
   <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
   gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
   application-default login``.

--- a/docs/examples/prometheus_exemplars/README.rst
+++ b/docs/examples/prometheus_exemplars/README.rst
@@ -37,10 +37,13 @@ traces to `Google Cloud Trace <https://cloud.google.com/trace/docs/overview>`_.
     }
 
 To run this example you first need to:
-    * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-    * Enable Cloud Trace API (listed in the Cloud Console as Stackdriver Trace API) in the project `here <https://console.cloud.google.com/apis/library?q=cloud%20trace&filter=visibility:public>`_. If the page says "API Enabled" then you're done! No need to do anything.
-    * Enable Default Application Credentials by creating setting `GOOGLE_APPLICATION_CREDENTIALS <https://cloud.google.com/docs/authentication/getting-started>`_ or by `installing gcloud sdk <https://cloud.google.com/sdk/install>`_ and calling ``gcloud auth application-default login``.
-    * Have docker and docker compose installed on your machine
+
+* Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
+* Enable `Application Default Credentials
+  <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
+  gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
+  application-default login``.
+* Have docker and docker compose installed on your machine
 
 Attaching Prometheus Exemplars
 ------------------------------

--- a/docs/examples/prometheus_exemplars/README.rst
+++ b/docs/examples/prometheus_exemplars/README.rst
@@ -39,7 +39,7 @@ traces to `Google Cloud Trace <https://cloud.google.com/trace/docs/overview>`_.
 To run this example you first need to:
 
 * Create a Google Cloud project. You can `create one here <https://console.cloud.google.com/projectcreate>`_.
-* Enable `Application Default Credentials
+* Set up `Application Default Credentials
   <https://cloud.google.com/docs/authentication/provide-credentials-adc>`_ by `installing
   gcloud <https://cloud.google.com/sdk/install>`_ and running ``gcloud auth
   application-default login``.


### PR DESCRIPTION
staged at https://google-cloud-opentelemetry--247.org.readthedocs.build/en/247/

- Reword instructions for getting Application Default Credentials
- Removed instructions to enable Trace/Monitoring APIs since they are [enabled by default](https://cloud.google.com/service-usage/docs/enabled-service#default)
- Fixed list RST markup through all documents to remove ugly indentation