### PR TITLE
Update snapshot tests and pin upstream versions

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -13,3 +13,8 @@ types-protobuf==3.20.4.2
 types-requests==2.28.11.2
 types-setuptools==65.5.0.2
 types-urllib3==1.26.25.1
+
+# pinned for snapshot tests. this should be bumped regularly and snapshots updated by running
+# tox -f py311-test -- --snapshot-update
+opentelemetry-api==1.18.0
+opentelemetry-sdk==1.18.0

--- a/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
+++ b/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
@@ -19,7 +19,7 @@
     'service.name': 'unknown_service',
     'telemetry.sdk.language': 'python',
     'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.17.0',
+    'telemetry.sdk.version': '1.18.0',
   })
 # ---
 # name: test_detects_gke[regional]
@@ -33,7 +33,7 @@
     'service.name': 'unknown_service',
     'telemetry.sdk.language': 'python',
     'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.17.0',
+    'telemetry.sdk.version': '1.18.0',
   })
 # ---
 # name: test_detects_gke[zonal]
@@ -47,6 +47,6 @@
     'service.name': 'unknown_service',
     'telemetry.sdk.language': 'python',
     'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.17.0',
+    'telemetry.sdk.version': '1.18.0',
   })
 # ---


### PR DESCRIPTION
Pinning the version should prevent the user agent strings from breaking every tiem a new release is made. The pinned version should be regularly bumped (dependabot or renovate would work nice here).