### PR TITLE
Don't use `pkg_resources.get_distribution(..).version`

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -19,7 +19,6 @@ from time import time_ns
 from typing import Dict, List, NoReturn, Optional, Set, Union
 
 import google.auth
-import pkg_resources
 from google.api.distribution_pb2 import Distribution
 from google.api.label_pb2 import LabelDescriptor
 from google.api.metric_pb2 import Metric as GMetric
@@ -44,6 +43,7 @@ from opentelemetry.exporter.cloud_monitoring.version import __version__
 from opentelemetry.resourcedetector.gcp_resource_detector._mapping import (
     get_monitored_resource,
 )
+from opentelemetry.sdk import version as opentelemetry_sdk_version
 from opentelemetry.sdk.metrics.export import (
     Gauge,
     Histogram,
@@ -62,7 +62,7 @@ WRITE_INTERVAL = 10
 UNIQUE_IDENTIFIER_KEY = "opentelemetry_id"
 NANOS_PER_SECOND = 10**9
 
-_OTEL_SDK_VERSION = pkg_resources.get_distribution("opentelemetry-sdk").version
+_OTEL_SDK_VERSION = opentelemetry_sdk_version.__version__
 _USER_AGENT = f"opentelemetry-python {_OTEL_SDK_VERSION}; google-cloud-metric-exporter {__version__}"
 
 # Set user-agent metadata, see https://github.com/grpc/grpc/issues/23644 and default options

--- a/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -87,7 +87,6 @@ from typing import (
 
 import google.auth
 import opentelemetry.trace as trace_api
-import pkg_resources
 from google.cloud.trace_v2 import BatchWriteSpansRequest, TraceServiceClient
 from google.cloud.trace_v2 import types as trace_types
 from google.cloud.trace_v2.services.trace_service.transports import (
@@ -108,6 +107,7 @@ from opentelemetry.resourcedetector.gcp_resource_detector import (
 from opentelemetry.resourcedetector.gcp_resource_detector._mapping import (
     get_monitored_resource,
 )
+from opentelemetry.sdk import version as opentelemetry_sdk_version
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event
 from opentelemetry.sdk.trace.export import (
@@ -122,7 +122,7 @@ from opentelemetry.util import types
 
 logger = logging.getLogger(__name__)
 
-_OTEL_SDK_VERSION = pkg_resources.get_distribution("opentelemetry-sdk").version
+_OTEL_SDK_VERSION = opentelemetry_sdk_version.__version__
 _USER_AGENT = f"opentelemetry-python {_OTEL_SDK_VERSION}; google-cloud-trace-exporter {__version__}"
 
 # Set user-agent metadata, see https://github.com/grpc/grpc/issues/23644 and default options
@@ -493,9 +493,7 @@ def _extract_attributes(
     if add_agent_attr:
         attributes_dict["g.co/agent"] = _format_attribute_value(
             "opentelemetry-python {}; google-cloud-trace-exporter {}".format(
-                _strip_characters(
-                    pkg_resources.get_distribution("opentelemetry-sdk").version
-                ),
+                _strip_characters(_OTEL_SDK_VERSION),
                 _strip_characters(__version__),
             )
         )

--- a/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_exporter.py
+++ b/opentelemetry-exporter-gcp-trace/tests/test_cloud_trace_exporter.py
@@ -16,7 +16,6 @@ import re
 import unittest
 from unittest import mock
 
-import pkg_resources
 from google.cloud.trace_v2.services.trace_service.transports import (
     TraceServiceGrpcTransport,
 )
@@ -43,6 +42,7 @@ from opentelemetry.exporter.cloud_trace import (
     _truncate_str,
 )
 from opentelemetry.exporter.cloud_trace.version import __version__
+from opentelemetry.sdk import version as opentelemetry_sdk_version
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event
 from opentelemetry.sdk.trace import _Span as Span
@@ -94,9 +94,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
         )
         cls.agent_code = _format_attribute_value(
             "opentelemetry-python {}; google-cloud-trace-exporter {}".format(
-                _strip_characters(
-                    pkg_resources.get_distribution("opentelemetry-sdk").version
-                ),
+                _strip_characters(opentelemetry_sdk_version.__version__),
                 _strip_characters(__version__),
             )
         )

--- a/tox.ini
+++ b/tox.ini
@@ -65,12 +65,14 @@ passenv = SKIP_GET_MOCK_SERVER
 changedir = {env:PACKAGE_NAME}
 
 commands_pre =
-  pip install .
+  pip install -c {toxinidir}/dev-constraints.txt .
   {toxinidir}/get_mock_server.sh {envbindir}
 
 commands = pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml {posargs}
 
-whitelist_externals = bash
+allowlist_externals = 
+  bash
+  {toxinidir}/get_mock_server.sh
 
 [testenv:{lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 basepython = {[constants]dev_basepython}
@@ -80,7 +82,7 @@ deps =
 changedir = {env:PACKAGE_NAME}
 
 commands_pre =
-  pip install .
+  pip install -c {toxinidir}/dev-constraints.txt .
 
 commands =
   lint: black . --diff --check
@@ -98,7 +100,7 @@ deps =
 commands =
   make -C docs/ clean html
 
-whitelist_externals =
+allowlist_externals =
   make
   bash
 


### PR DESCRIPTION
Similar to discussion at googleapis/python-api-core#27 I am using opentelemetry in an environment where modules are vendored without pip. So, pkg_resources can not be used to search for a module at runtime to get its version.