### PR TITLE
Remove instruction to install `tox-factor`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,7 +43,7 @@ This project uses [tox](https://tox.readthedocs.io/en/latest/index.html) for
 development, so make sure it is installed on your system:
 
 ```sh
-pip install tox tox-factor
+pip install tox
 ```
 
 To create a virtual environment `venv/` at the root of the repository (useful


### PR DESCRIPTION
This is no longer necessary with tox version 4, and creates a confusing error message.

https://github.com/rpkilby/tox-factor/issues/18