### PR TITLE
Pin upstream version of opentelemetry when running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,12 +65,14 @@ passenv = SKIP_GET_MOCK_SERVER
 changedir = {env:PACKAGE_NAME}
 
 commands_pre =
-  pip install .
+  pip install -c {toxinidir}/dev-constraints.txt .
   {toxinidir}/get_mock_server.sh {envbindir}
 
 commands = pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml {posargs}
 
-whitelist_externals = bash
+allowlist_externals = 
+  bash
+  {toxinidir}/get_mock_server.sh
 
 [testenv:{lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 basepython = {[constants]dev_basepython}
@@ -80,7 +82,7 @@ deps =
 changedir = {env:PACKAGE_NAME}
 
 commands_pre =
-  pip install .
+  pip install -c {toxinidir}/dev-constraints.txt .
 
 commands =
   lint: black . --diff --check
@@ -98,7 +100,7 @@ deps =
 commands =
   make -C docs/ clean html
 
-whitelist_externals =
+allowlist_externals =
   make
   bash
 


### PR DESCRIPTION
The fix in #254 didn't apply to tox environments that run `pip install .`

In #256 `test_detects_gce` was failing with opentelemetry-sdk version 1.19.0 instead of 1.18.0

Also fix `get_mock_server.sh` not being in `allowlist_externals`