### PR TITLE
Map faas.* attributes to generic_task in resource mapping

### DIFF
--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_constants.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_constants.py
@@ -35,6 +35,8 @@ class ResourceAttributes:
     SERVICE_INSTANCE_ID = "service.instance.id"
     SERVICE_NAME = "service.name"
     SERVICE_NAMESPACE = "service.namespace"
+    FAAS_INSTANCE = "faas.instance"
+    FAAS_NAME = "faas.name"
 
 
 AWS_ACCOUNT = "aws_account"
@@ -59,3 +61,4 @@ POD_NAME = "pod_name"
 REGION = "region"
 TASK_ID = "task_id"
 ZONE = "zone"
+UNKNOWN_SERVICE_PREFIX = "unknown_service"

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
@@ -173,11 +173,8 @@ def get_monitored_resource(
     else:
         # fallback to generic_task
         if (
-            ResourceAttributes.SERVICE_NAME in attrs
-            and ResourceAttributes.SERVICE_INSTANCE_ID in attrs
-        ) or (
-            ResourceAttributes.FAAS_NAME in attrs
-            and ResourceAttributes.FAAS_INSTANCE in attrs
+            (ResourceAttributes.SERVICE_NAME in attrs or ResourceAttributes.FAAS_NAME in attrs)
+            and (ResourceAttributes.SERVICE_INSTANCE_ID in attrs or ResourceAttributes.FAAS_INSTANCE in attrs)
         ):
             mr = _create_monitored_resource(_constants.GENERIC_TASK, attrs)
         else:
@@ -194,24 +191,14 @@ def _create_monitored_resource(
 
     for mr_key, map_config in mapping.items():
         mr_value = None
-        fallback_value = None
         for otel_key in map_config.otel_keys:
-            if otel_key in resource_attrs:
-                if (
-                    otel_key == ResourceAttributes.SERVICE_NAME
-                    and isinstance(resource_attrs[otel_key], str)
-                    and str(resource_attrs[otel_key]).startswith(
-                        _constants.UNKNOWN_SERVICE_PREFIX
-                    )
-                ):
-                    # Only use values with an unknown_service prefix as the last resort
-                    fallback_value = resource_attrs[otel_key]
-                else:
-                    mr_value = resource_attrs[otel_key]
-                    break
+            if otel_key in resource_attrs and not str(resource_attrs[otel_key]).startswith(_constants.UNKNOWN_SERVICE_PREFIX):
+                mr_value = resource_attrs[otel_key]
+                break
 
-        if mr_value is None:
-            mr_value = fallback_value
+        if mr_value is None and ResourceAttributes.SERVICE_NAME in map_config.otel_keys:
+            # The service name started with unknown_service, and was ignored above.
+            mr_value = resource_attrs[ResourceAttributes.SERVICE_NAME]
 
         if mr_value is None:
             mr_value = map_config.fallback

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
@@ -206,7 +206,7 @@ def _create_monitored_resource(
             and ResourceAttributes.SERVICE_NAME in map_config.otel_keys
         ):
             # The service name started with unknown_service, and was ignored above.
-            mr_value = resource_attrs[ResourceAttributes.SERVICE_NAME]
+            mr_value = resource_attrs.get(ResourceAttributes.SERVICE_NAME)
 
         if mr_value is None:
             mr_value = map_config.fallback

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_mapping.py
@@ -173,8 +173,11 @@ def get_monitored_resource(
     else:
         # fallback to generic_task
         if (
-            (ResourceAttributes.SERVICE_NAME in attrs or ResourceAttributes.FAAS_NAME in attrs)
-            and (ResourceAttributes.SERVICE_INSTANCE_ID in attrs or ResourceAttributes.FAAS_INSTANCE in attrs)
+            ResourceAttributes.SERVICE_NAME in attrs
+            or ResourceAttributes.FAAS_NAME in attrs
+        ) and (
+            ResourceAttributes.SERVICE_INSTANCE_ID in attrs
+            or ResourceAttributes.FAAS_INSTANCE in attrs
         ):
             mr = _create_monitored_resource(_constants.GENERIC_TASK, attrs)
         else:
@@ -192,11 +195,16 @@ def _create_monitored_resource(
     for mr_key, map_config in mapping.items():
         mr_value = None
         for otel_key in map_config.otel_keys:
-            if otel_key in resource_attrs and not str(resource_attrs[otel_key]).startswith(_constants.UNKNOWN_SERVICE_PREFIX):
+            if otel_key in resource_attrs and not str(
+                resource_attrs[otel_key]
+            ).startswith(_constants.UNKNOWN_SERVICE_PREFIX):
                 mr_value = resource_attrs[otel_key]
                 break
 
-        if mr_value is None and ResourceAttributes.SERVICE_NAME in map_config.otel_keys:
+        if (
+            mr_value is None
+            and ResourceAttributes.SERVICE_NAME in map_config.otel_keys
+        ):
             # The service name started with unknown_service, and was ignored above.
             mr_value = resource_attrs[ResourceAttributes.SERVICE_NAME]
 

--- a/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_mapping.ambr
+++ b/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_mapping.ambr
@@ -98,6 +98,17 @@
     'type': 'generic_task',
   })
 # ---
+# name: test_get_monitored_resource[generic task faas]
+  dict({
+    'labels': dict({
+      'job': 'faasname',
+      'location': 'myregion',
+      'namespace': 'servicens',
+      'task_id': 'faasinstance',
+    }),
+    'type': 'generic_task',
+  })
+# ---
 # name: test_get_monitored_resource[generic task fallback region]
   dict({
     'labels': dict({

--- a/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_mapping.ambr
+++ b/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_mapping.ambr
@@ -109,6 +109,17 @@
     'type': 'generic_task',
   })
 # ---
+# name: test_get_monitored_resource[generic task faas fallback]
+  dict({
+    'labels': dict({
+      'job': 'unknown_service',
+      'location': 'myregion',
+      'namespace': 'servicens',
+      'task_id': 'faasinstance',
+    }),
+    'type': 'generic_task',
+  })
+# ---
 # name: test_get_monitored_resource[generic task fallback region]
   dict({
     'labels': dict({

--- a/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
@@ -164,6 +164,15 @@ from syrupy.assertion import SnapshotAssertion
             },
             id="generic task fallback global",
         ),
+        pytest.param(
+            {
+                "cloud.region": "myregion",
+                "service.namespace": "servicens",
+                "faas.name": "faasname",
+                "faas.instance": "faasinstance",
+            },
+            id="generic task faas",
+        ),
         # generic node
         pytest.param(
             {

--- a/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
@@ -173,6 +173,14 @@ from syrupy.assertion import SnapshotAssertion
             },
             id="generic task faas",
         ),
+        pytest.param(
+            {
+                "cloud.region": "myregion",
+                "service.namespace": "servicens",
+                "faas.instance": "faasinstance",
+            },
+            id="generic task faas fallback",
+        ),
         # generic node
         pytest.param(
             {

--- a/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
+++ b/opentelemetry-resourcedetector-gcp/tests/test_mapping.py
@@ -166,6 +166,7 @@ from syrupy.assertion import SnapshotAssertion
         ),
         pytest.param(
             {
+                "service.name": "unknown_service",
                 "cloud.region": "myregion",
                 "service.namespace": "servicens",
                 "faas.name": "faasname",
@@ -175,6 +176,7 @@ from syrupy.assertion import SnapshotAssertion
         ),
         pytest.param(
             {
+                "service.name": "unknown_service",
                 "cloud.region": "myregion",
                 "service.namespace": "servicens",
                 "faas.instance": "faasinstance",
@@ -230,7 +232,7 @@ from syrupy.assertion import SnapshotAssertion
 def test_get_monitored_resource(
     otel_attributes: Attributes, snapshot: SnapshotAssertion
 ) -> None:
-    resource = Resource.create(otel_attributes)
+    resource = Resource(otel_attributes)
     monitored_resource_data = get_monitored_resource(resource)
     as_dict = dataclasses.asdict(monitored_resource_data)
     assert as_dict == snapshot


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/272

Question: should faas.* attributes take precedence over service.* attributes if they are present?  If they do, it might break users who are currently using service.* attributes.  If we don't, the default service (unknown) will take precedence over faas.name