### PR TITLE
Fix ReadTheDocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,10 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 python:
-  version: 3.8
   install:
     - requirements: docs-requirements.txt


### PR DESCRIPTION
Seeing this in the failed builds:

> The configuration key "build.image" is deprecated. Use "build.os" instead to continue building your project. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

Updating following [this](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#use-a-requirements-file-for-python-dependencies). Build passed on ReadTheDocs: https://readthedocs.org/projects/google-cloud-opentelemetry/builds/22257801/
