### PR TITLE
Add OTLP trace sample with GCP auth

### DIFF
--- a/samples/otlptrace/example.py
+++ b/samples/otlptrace/example.py
@@ -16,18 +16,21 @@
 import google.auth
 import google.auth.transport.requests
 from google.auth.transport.requests import AuthorizedSession
-
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 credentials, project_id = google.auth.default()
 request = google.auth.transport.requests.Request()
 credentials.refresh(request)
-req_headers = {'x-goog-user-project':credentials.quota_project_id,'Authorization':'Bearer '+credentials.token}
+req_headers = {
+    "x-goog-user-project": credentials.quota_project_id,
+    "Authorization": "Bearer " + credentials.token,
+}
 
 traceProvider = TracerProvider()
 processor = BatchSpanProcessor(OTLPSpanExporter(headers=req_headers))
@@ -35,10 +38,12 @@ traceProvider.add_span_processor(processor)
 trace.set_tracer_provider(traceProvider)
 tracer = trace.get_tracer("my.tracer.name")
 
+
 def do_work():
     with tracer.start_as_current_span("span-name") as span:
         # do some work that 'span' will track
         print("doing some work...")
         # When the 'with' block goes out of scope, 'span' is closed for you
+
 
 do_work()

--- a/samples/otlptrace/example.py
+++ b/samples/otlptrace/example.py
@@ -27,14 +27,9 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 credentials, project_id = google.auth.default()
 request = google.auth.transport.requests.Request()
 credentials.refresh(request)
-req_headers = {'x-goog-user-project':credentials.quota_project_id,'Authorization':'Bearer: '+credentials.token}
+req_headers = {'x-goog-user-project':credentials.quota_project_id,'Authorization':'Bearer '+credentials.token}
 
-# Service name is required for most backends
-resource = Resource(attributes={
-    SERVICE_NAME: "your-service-name"
-})
-
-traceProvider = TracerProvider(resource=resource)
+traceProvider = TracerProvider()
 processor = BatchSpanProcessor(OTLPSpanExporter(headers=req_headers))
 traceProvider.add_span_processor(processor)
 trace.set_tracer_provider(traceProvider)

--- a/samples/otlptrace/example.py
+++ b/samples/otlptrace/example.py
@@ -32,10 +32,10 @@ req_headers = {
     "Authorization": "Bearer " + credentials.token,
 }
 
-traceProvider = TracerProvider()
+trace_provider = TracerProvider()
 processor = BatchSpanProcessor(OTLPSpanExporter(headers=req_headers))
-traceProvider.add_span_processor(processor)
-trace.set_tracer_provider(traceProvider)
+trace_provider.add_span_processor(processor)
+trace.set_tracer_provider(trace_provider)
 tracer = trace.get_tracer("my.tracer.name")
 
 

--- a/samples/otlptrace/example.py
+++ b/samples/otlptrace/example.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import google.auth
+from google.auth.transport.requests import AuthorizedSession
+
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+credentials, project_id = google.auth.default()
+authed_session = AuthorizedSession(credentials)
+
+# Service name is required for most backends
+resource = Resource(attributes={
+    SERVICE_NAME: "your-service-name"
+})
+
+traceProvider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="<traces-endpoint>/v1/traces", headers=authed_session.headers))
+traceProvider.add_span_processor(processor)
+trace.set_tracer_provider(traceProvider)
+
+def do_work():
+    with tracer.start_as_current_span("span-name") as span:
+        # do some work that 'span' will track
+        print("doing some work...")
+        # When the 'with' block goes out of scope, 'span' is closed for you
+
+do_work()


### PR DESCRIPTION
Following some examples from https://opentelemetry.io/docs/languages/python/instrumentation/, https://opentelemetry.io/docs/languages/python/exporters/#otlp-dependencies, https://github.com/googleapis/google-auth-library-python/blob/main/samples/cloud-client/snippets/authenticate_explicit_with_adc.py, and https://googleapis.dev/python/google-auth/latest/user-guide.html#requests to try to get a Google auth client and pass the headers in exporter requests