### PR TITLE
Upgrade sphinx to fix docs build

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -7,7 +7,7 @@ isort==5.8.0
 mypy-extensions==0.4.3
 mypy==0.982
 pylint==2.8.3
-Sphinx==4.3.1
+Sphinx==7.2.6
 syrupy==3.0.4
 types-protobuf==3.20.4.2
 types-requests==2.28.11.2


### PR DESCRIPTION
Upgrade sphinx to fix docs build which was failing with

```    
docs-ci: commands[0]> make -C docs/ clean html    
make: Entering directory '/home/runner/work/opentelemetry-operations-python/opentelemetry-operations-python/docs'    
Running Sphinx v4.3.1    
    
Sphinx version error:    
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.    
make: *** [Makefile:20: html] Error 2    
make: Leaving directory '/home/runner/work/opentelemetry-operations-python/opentelemetry-operations-python/docs'    
docs-ci: exit 2 (0.85 seconds) /home/runner/work/opentelemetry-operations-python/opentelemetry-operations-python> make -C docs/ clean html pid=1886    
docs-ci: FAIL code 2 (16.84=setup[15.99]+cmd[0.85] seconds)      
evaluation failed :( (17.38 seconds)      
```