### PR TITLE
Add WIP instrumentation quickstart sample

### DIFF
--- a/samples/instrumentation-quickstart/Dockerfile
+++ b/samples/instrumentation-quickstart/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /usr/src/app
 COPY . .
 RUN python -m venv /venv && \
     /venv/bin/pip install -r requirements.txt
+# TODO: Make this a more realistic productionized application using Gunicorn as a SWGI server.
+# See https://flask.palletsprojects.com/en/3.0.x/deploying/ 
 CMD . /venv/bin/activate && flask run --host 0.0.0.0 --port 8080 2>&1 | tee /var/log/app.log

--- a/samples/instrumentation-quickstart/Dockerfile
+++ b/samples/instrumentation-quickstart/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/src/app
 COPY . .
 RUN python -m venv /venv && \
     /venv/bin/pip install -r requirements.txt
-CMD bash -c "source /venv/bin/activate && flask run --host 0.0.0.0 --port 8080 2>&1 | tee /var/log/app.log"
+CMD . /venv/bin/activate && flask run --host 0.0.0.0 --port 8080 2>&1 | tee /var/log/app.log

--- a/samples/instrumentation-quickstart/Dockerfile
+++ b/samples/instrumentation-quickstart/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12
+WORKDIR /usr/src/app
+COPY . .
+RUN python -m venv /venv && \
+    /venv/bin/pip install -r requirements.txt
+CMD bash -c "source /venv/bin/activate && flask run --host 0.0.0.0 --port 8080 2>&1 | tee /var/log/app.log"

--- a/samples/instrumentation-quickstart/README.md
+++ b/samples/instrumentation-quickstart/README.md
@@ -29,7 +29,7 @@ following roles to run the example:
 
 ```sh
 git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-python.git
-cd opentelemetry-operations-python/examples/instrumentation-quickstart
+cd opentelemetry-operations-python/samples/instrumentation-quickstart
 docker compose up --abort-on-container-exit
 ```
 
@@ -69,7 +69,7 @@ Then run the example:
 
 ```sh
 git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-python.git
-cd opentelemetry-operations-python/examples/instrumentation-quickstart
+cd opentelemetry-operations-python/samples/instrumentation-quickstart
 
 # Lets collector read mounted config
 export USERID="$(id -u)"

--- a/samples/instrumentation-quickstart/README.md
+++ b/samples/instrumentation-quickstart/README.md
@@ -1,0 +1,88 @@
+# OpenTelemetry Python instrumentation example
+
+**This example is under development, and does not currently work**
+
+This sample is a Python application instrumented with TODO. This is a python version
+of [this golang
+sample](https://github.com/GoogleCloudPlatform/golang-samples/tree/main/opentelemetry/instrumentation).
+It uses docker compose to run the application and send it some requests.
+
+The Python code is a Flask application with two endpoints
+- `/multi` makes a few requests to `/single` on localhost
+- `/single` sleeps for a short time to simulate work
+
+Docker compose also runs the OpenTelemetry collector, set up to receive telemetry from the Python
+application and parse its logs from a shared volume. Finally, a loadgen container sends
+requests to the Python app.
+
+## Permissions
+
+This sample writes to Cloud Logging, Cloud Monitoring, and Cloud Trace. Grant yourself the
+following roles to run the example:
+- `roles/logging.logWriter` – see https://cloud.google.com/logging/docs/access-control#permissions_and_roles
+- `roles/monitoring.metricWriter` – see https://cloud.google.com/monitoring/access-control#predefined_roles
+- `roles/cloudtrace.agent` – see https://cloud.google.com/trace/docs/iam#trace-roles
+
+## Running the example
+
+### Cloud Shell or GCE
+
+```sh
+git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-python.git
+cd opentelemetry-operations-python/examples/instrumentation-quickstart
+docker compose up --abort-on-container-exit
+```
+
+### Locally with Application Default Credentials
+
+First Create local credentials by running the following command and following the
+oauth2 flow (read more about the command [here][auth_command]):
+
+	gcloud auth application-default login
+
+> [!CAUTION]
+> This method of authentication is not recommended for production environments.
+
+Executing this command will save your application credentials to the default path which will depend on the type of machine -
+- Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
+- Windows: `%APPDATA%\gcloud\application_default_credentials.json`
+
+Next, export the credentials to `GOOGLE_APPLICATION_CREDENTIALS` environment variable -
+
+For Linux & MacOS:
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
+```
+
+For Windows:
+```shell
+SET GOOGLE_APPLICATION_CREDENTIALS=%APPDATA%\gcloud\application_default_credentials.json
+```
+
+You can also manually set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to a service account key JSON file path.
+
+Learn more at [Setting Up Authentication for Server to Server Production Applications][ADC].
+
+*Note:* Application Default Credentials is able to implicitly find the credentials as long as the application is running on Compute Engine, Kubernetes Engine, App Engine, or Cloud Functions.
+
+Then run the example:
+
+```sh
+git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-python.git
+cd opentelemetry-operations-python/examples/instrumentation-quickstart
+
+# Lets collector read mounted config
+export USERID="$(id -u)"
+# Specify the project ID
+export GOOGLE_CLOUD_PROJECT=<your project id>
+docker compose -f docker-compose.yaml -f docker-compose.creds.yaml up  --abort-on-container-exit
+```
+
+## Viewing the results
+
+After a successful run of the example, you can see the generated metrics in the GCP console via Metrics Explorer. The generated metrics would be present under the `Prometheus Target` resource.
+
+Similarly, to view the generated traces in the GCP console, use the Trace Explorer.
+
+[auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
+[ADC]: https://cloud.google.com/docs/authentication/application-default-credentials

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -17,7 +17,7 @@ from flask import Flask, url_for
 import requests
 import time
 
-app = Flask(__name__, static_folder=None)
+app = Flask(__name__)
 
 # TODO: change the logging format to conform to GCP requirements
 # TODO: Add manual metric instrumentation

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from random import randint, uniform
+from flask import Flask, url_for
+import requests
+import time
+
+app = Flask(__name__, static_folder=None)
+
+# TODO: change the logging format to conform to GCP requirements
+# TODO: Add manual metric instrumentation
+# TODO: Add manual trace instrumentation
+
+@app.route('/multi')
+def multi():
+    # TODO: add info log line here
+    for _ in range(randint(3, 7)):
+        requests.get(url_for('single', _external=True))
+    return 'ok'
+
+@app.route('/single')
+def single():
+    duration = uniform(0.1, 0.2)
+    time.sleep(duration)
+    return 'slept ' + str(duration) + ' seconds'

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -34,4 +34,4 @@ def multi():
 def single():
     duration = uniform(0.1, 0.2)
     time.sleep(duration)
-    return 'slept ' + str(duration) + ' seconds'
+    return f'slept {duration} seconds'

--- a/samples/instrumentation-quickstart/docker-compose.creds.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.creds.yaml
@@ -1,0 +1,35 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this compose file along with docker-compose.yaml to pass a credentials file from the host
+# into the collector container:
+#
+# ```
+# GOOGLE_CLOUD_PROJECT="otel-quickstart-demos" \
+# GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json" \
+# USERID="$(id -u)" \
+# docker compose -f docker-compose.yaml -f docker-compose.creds.yaml up --abort-on-container-exit
+# ```
+
+version: "3"
+
+services:
+  otelcol:
+    # If the collector does not have permission to read the mounted volumes, set
+    # USERID=$(id -u) to run the container as the current user
+    user: $USERID
+    volumes:
+      - ${GOOGLE_APPLICATION_CREDENTIALS?}:${GOOGLE_APPLICATION_CREDENTIALS}:ro
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS

--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3'
+
+services:
+  app:
+    build: .
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
+      - OTEL_SERVICE_NAME=otel-quickstart-python
+    volumes:
+      - logs:/var/log:rw
+    depends_on:
+      - "otelcol"
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.92.0
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+      - logs:/var/log:ro
+    environment:
+      - GOOGLE_CLOUD_QUOTA_PROJECT
+      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT?}
+  loadgen:
+    image: golang:1.21
+    command: ["go", "run", "github.com/rakyll/hey@latest", "-c=2", "-q=1", "http://app:8080/multi"]
+    depends_on:
+      - "app"
+volumes:
+  logs:

--- a/samples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/samples/instrumentation-quickstart/otel-collector-config.yaml
@@ -1,0 +1,126 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+receivers:
+  # Receive OTLP from our application
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4318"
+      grpc:
+        endpoint: "0.0.0.0:4317"
+
+  # Use the filelog receiver to read the application's logs from its log file.
+  # This config reads JSON logs in same format that the Cloud Logging agents
+  # support:
+  # https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+  filelog:
+    start_at: beginning
+    include:
+    - "/var/log/app.log"
+    operators:
+      - type: json_parser
+        parse_to: body
+        timestamp:
+          parse_from: body.timestamp
+          layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+        severity:
+          parse_from: body.severity
+          preset: none
+          # parse minimal set of severity strings that Cloud Logging explicitly supports
+          # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+          mapping:
+            debug: debug
+            info: info
+            info3: notice
+            warn: warning
+            error: error
+            fatal: critical
+            fatal3: alert
+            fatal4: emergency
+
+      # set trace_flags to SAMPLED if GCP attribute is set to true
+      - type: add
+        field: body.trace_flags
+        value: "01"
+        if: body["logging.googleapis.com/trace_sampled"] == true
+
+      # parse the trace context fields from GCP attributes
+      - type: regex_parser
+        parse_from: body["logging.googleapis.com/trace"]
+        parse_to: body
+        regex: (?P<trace_id>.*)
+        trace:
+          span_id:
+            parse_from: body["logging.googleapis.com/spanId"]
+
+      # Remove fields that are redundant from translation above and already
+      # included in OTel LogEntry message
+      - type: remove
+        field: body.timestamp
+      - type: remove
+        field: body.trace_id
+      - type: remove
+        field: body.trace_flags
+      - type: remove
+        field: body.severity
+      - type: remove
+        field: body["logging.googleapis.com/trace"]
+      - type: remove
+        field: body["logging.googleapis.com/spanId"]
+      - type: remove
+        field: body["logging.googleapis.com/trace_sampled"]
+
+exporters:
+  # Export logs and traces using the standard googelcloud exporter
+  googlecloud:
+    project: $GOOGLE_CLOUD_PROJECT
+    log:
+      default_log_name: "opentelemetry.io/collector-exported-log"
+  # Export metrics to Google Managed service for Prometheus
+  googlemanagedprometheus:
+    project: $GOOGLE_CLOUD_PROJECT
+
+processors:
+  # Batch telemetry together to more efficiently send to GCP
+  batch:
+    send_batch_max_size: 500
+    send_batch_size: 500
+    timeout: 1s
+  # Make sure Google Managed service for Prometheus required labels are set
+  resource:
+    attributes:
+      - { key: "location", value: "us-central1", action: "upsert" }
+      - { key: "cluster", value: "no-cluster", action: "upsert" }
+      - { key: "namespace", value: "no-namespace", action: "upsert" }
+      - { key: "job", value: "us-job", action: "upsert" }
+      - { key: "instance", value: "us-instance", action: "upsert" }
+  # If running on GCP (e.g. on GKE), detect resource attributes from the environment.
+  resourcedetection:
+    detectors: ["env", "gcp"]
+
+service:
+  pipelines:
+    traces:
+      receivers: ["otlp"]
+      processors: ["batch", "resourcedetection"]
+      exporters: ["googlecloud"]
+    metrics:
+      receivers: ["otlp"]
+      processors: ["batch", "resourcedetection", "resource"]
+      exporters: ["googlemanagedprometheus"]
+    logs:
+      receivers: ["filelog"]
+      processors: ["batch", "resourcedetection"]
+      exporters: ["googlecloud"]

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -1,0 +1,3 @@
+# Dependencies require for the instrumentation sample
+flask==3.0.2
+requests==2.31.0


### PR DESCRIPTION
This is mostly boilerplate to make future PRs smaller.

The following are taken from https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/309:

* `samples/instrumentation-quickstart/Dockerfile`
* `samples/instrumentation-quickstart/app.py`

The following are minimally adapted from the java quickstart:

* samples/instrumentation-quickstart/README.md
* samples/instrumentation-quickstart/docker-compose.creds.yaml
* samples/instrumentation-quickstart/docker-compose.yaml

The quickstart runs and serves requests, but does not currently include any instrumentation.  The logs are also not in the correct format.

~~I noticed we have some examples in docs/examples, and another example in /samples.  Should we consolidate?~~