### PR TITLE
Add metrics and traces to the OTel quickstart using flask instrumentation

### DIFF
--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -14,14 +14,14 @@
 
 from random import randint, uniform
 from flask import Flask, url_for
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
 import requests
 import time
 
 app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
 
 # TODO: change the logging format to conform to GCP requirements
-# TODO: Add manual metric instrumentation
-# TODO: Add manual trace instrumentation
 
 @app.route('/multi')
 def multi():

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from random import randint, uniform
-import requests
 import time
 
 from opentelemetry import trace
@@ -25,6 +24,9 @@ from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+import requests
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
 from flask import Flask, url_for
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
@@ -42,10 +44,9 @@ metrics.set_meter_provider(meterProvider)
 
 app = Flask(__name__)
 FlaskInstrumentor().instrument_app(app)
+RequestsInstrumentor().instrument()
 
 # TODO: change the logging format to conform to GCP requirements
-# TODO: figure out how to get exemplars on metrics
-# TODO: Connect multi and single spans using context propagation
 
 @app.route('/multi')
 def multi():

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -2,3 +2,6 @@
 flask==3.0.2
 requests==2.31.0
 opentelemetry-instrumentation-flask==0.45b0
+opentelemetry-api==1.24.0
+opentelemetry-sdk==1.24.0
+opentelemetry-exporter-otlp-proto-http==1.24.0

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -1,7 +1,8 @@
 # Dependencies require for the instrumentation sample
 flask==3.0.2
 requests==2.31.0
-opentelemetry-instrumentation-flask==0.45b0
 opentelemetry-api==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-exporter-otlp-proto-http==1.24.0
+opentelemetry-instrumentation-flask==0.45b0
+opentelemetry-instrumentation-requests==0.45b0

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -1,3 +1,4 @@
 # Dependencies require for the instrumentation sample
 flask==3.0.2
 requests==2.31.0
+opentelemetry-instrumentation-flask==0.45b0


### PR DESCRIPTION
Adds flask and requests instrumentation, and configures the OpenTelemetry trace and metrics SDK

<img width="1459" alt="Screenshot 2024-05-09 at 10 10 23 PM" src="https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/assets/3262098/5521b74e-fb8d-41f2-a856-e50c1ea50f53">

<img width="1459" alt="Screenshot 2024-05-10 at 12 10 34 PM" src="https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/assets/3262098/e3738ccf-a62e-4278-bdbc-78a6b1526c20">

