### PR TITLE
Add json logging to the sample application

### DIFF
--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -17,6 +17,7 @@ import time
 
 import logging
 from pythonjsonlogger import jsonlogger
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -34,14 +35,20 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from flask import Flask, url_for
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 
-# TODO: log span context using GCP keys
+LoggingInstrumentor().instrument()
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 logHandler = logging.StreamHandler()
 formatter = jsonlogger.JsonFormatter(
-    "%(asctime)s %(levelname)s %(message)s",
-    rename_fields={"levelname": "severity", "asctime": "timestamp"},
+    "%(asctime)s %(levelname)s %(message)s %(otelTraceID)s %(otelSpanID)s %(otelTraceSampled)s",
+    rename_fields={
+        "levelname": "severity",
+        "asctime": "timestamp",
+        "otelTraceID": "logging.googleapis.com/trace",
+        "otelSpanID": "logging.googleapis.com/spanId",
+        "otelTraceSampled": "logging.googleapis.com/trace_sampled",
+        },
     datefmt="%Y-%m-%dT%H:%M:%SZ",
 )
 logHandler.setFormatter(formatter)

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -6,4 +6,5 @@ opentelemetry-sdk==1.24.0
 opentelemetry-exporter-otlp-proto-http==1.24.0
 opentelemetry-instrumentation-flask==0.45b0
 opentelemetry-instrumentation-requests==0.45b0
+opentelemetry-instrumentation-logging==0.45b0
 python-json-logger==2.0.7

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -6,3 +6,4 @@ opentelemetry-sdk==1.24.0
 opentelemetry-exporter-otlp-proto-http==1.24.0
 opentelemetry-instrumentation-flask==0.45b0
 opentelemetry-instrumentation-requests==0.45b0
+python-json-logger==2.0.7


### PR DESCRIPTION
This uses `python-json-logger` to do the json formatting, and changes the keys used to match what GCP expects.  All loglevels seem to work properly.  I did not investigate other logging libraries, since the existing GCP docs already recommend using `logging`.

<img width="1357" alt="Screenshot 2024-05-10 at 2 43 53 PM" src="https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/assets/3262098/e88eca88-0d0f-46de-8887-25190af411a0">

The second commit adds the trace context keys.  I used `opentelemetry-instrumentation-logging` to make the keys available to the logger, and used `rename_fields` to set the proper GCP keys for the trace context.