### PR TITLE
Change the sample to use gunicorn

### DIFF
--- a/samples/instrumentation-quickstart/Dockerfile
+++ b/samples/instrumentation-quickstart/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/src/app
 COPY . .
 RUN python -m venv /venv && \
     /venv/bin/pip install -r requirements.txt
-CMD . /venv/bin/activate && gunicorn -b 0.0.0.0:8080 -w 4 'app:app'  2>&1 | tee /var/log/app.log
+CMD /venv/bin/gunicorn -b 0.0.0.0:8080 -w 4 'app:app'  2>&1 | tee /var/log/app.log

--- a/samples/instrumentation-quickstart/Dockerfile
+++ b/samples/instrumentation-quickstart/Dockerfile
@@ -3,6 +3,4 @@ WORKDIR /usr/src/app
 COPY . .
 RUN python -m venv /venv && \
     /venv/bin/pip install -r requirements.txt
-# TODO: Make this a more realistic productionized application using Gunicorn as a SWGI server.
-# See https://flask.palletsprojects.com/en/3.0.x/deploying/ 
-CMD . /venv/bin/activate && flask run --host 0.0.0.0 --port 8080 2>&1 | tee /var/log/app.log
+CMD . /venv/bin/activate && gunicorn -b 0.0.0.0:8080 -w 4 'app:app'  2>&1 | tee /var/log/app.log

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 from random import randint, uniform
+import os
 import time
 
 import logging
 from pythonjsonlogger import jsonlogger
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, SERVICE_NAME, Resource
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -56,7 +59,14 @@ logger.addHandler(logHandler)
 # disable logging from Flask until we use Gunicorn
 logging.getLogger('werkzeug').setLevel(logging.ERROR)
 
-traceProvider = TracerProvider()
+resource = Resource(attributes={
+    # Use the PID as the service.instance.id to avoid duplicate timeseries
+    # from different Gunicorn worker processes.
+    SERVICE_INSTANCE_ID: str(os.getpid()),
+    SERVICE_NAME: "otel-quickstart-python",
+})
+
+traceProvider = TracerProvider(resource=resource)
 processor = BatchSpanProcessor(OTLPSpanExporter())
 traceProvider.add_span_processor(processor)
 trace.set_tracer_provider(traceProvider)
@@ -64,7 +74,7 @@ trace.set_tracer_provider(traceProvider)
 reader = PeriodicExportingMetricReader(
     OTLPMetricExporter()
 )
-meterProvider = MeterProvider(metric_readers=[reader])
+meterProvider = MeterProvider(metric_readers=[reader], resource=resource)
 metrics.set_meter_provider(meterProvider)
 
 app = Flask(__name__)

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -59,10 +59,10 @@ logger.addHandler(logHandler)
 # disable logging from Flask until we use Gunicorn
 logging.getLogger('werkzeug').setLevel(logging.ERROR)
 
-resource = Resource(attributes={
+resource = Resource.create(attributes={
     # Use the PID as the service.instance.id to avoid duplicate timeseries
     # from different Gunicorn worker processes.
-    SERVICE_INSTANCE_ID: str(os.getpid()),
+    SERVICE_INSTANCE_ID: f"worker-{os.getpid()}"
     SERVICE_NAME: "otel-quickstart-python",
 })
 

--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -62,8 +62,7 @@ logging.getLogger('werkzeug').setLevel(logging.ERROR)
 resource = Resource.create(attributes={
     # Use the PID as the service.instance.id to avoid duplicate timeseries
     # from different Gunicorn worker processes.
-    SERVICE_INSTANCE_ID: f"worker-{os.getpid()}"
-    SERVICE_NAME: "otel-quickstart-python",
+    SERVICE_INSTANCE_ID: f"worker-{os.getpid()}",
 })
 
 traceProvider = TracerProvider(resource=resource)

--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
     build: .
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
-      - OTEL_SERVICE_NAME=otel-quickstart-python
     volumes:
       - logs:/var/log:rw
     depends_on:

--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
     build: .
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
+      - OTEL_SERVICE_NAME=otel-quickstart-python
     volumes:
       - logs:/var/log:rw
     depends_on:

--- a/samples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/samples/instrumentation-quickstart/otel-collector-config.yaml
@@ -98,14 +98,14 @@ processors:
     send_batch_max_size: 500
     send_batch_size: 500
     timeout: 1s
-  # Make sure Google Managed service for Prometheus required labels are set
+  # Provide defaults for Google Managed Service for Prometheus labels
   resource:
     attributes:
-      - { key: "location", value: "us-central1", action: "upsert" }
-      - { key: "cluster", value: "no-cluster", action: "upsert" }
-      - { key: "namespace", value: "no-namespace", action: "upsert" }
-      - { key: "job", value: "us-job", action: "upsert" }
-      - { key: "instance", value: "us-instance", action: "upsert" }
+      - { key: "cloud.region", value: "us-central1", action: "insert" }
+      - { key: "k8s.cluster.name", value: "no-cluster", action: "insert" }
+      - { key: "k8s.namespace.name", value: "no-namespace", action: "insert" }
+      - { key: "service.name", value: "us-job", action: "insert" }
+      - { key: "service.instance.id", value: "us-instance", action: "insert" }
   # If running on GCP (e.g. on GKE), detect resource attributes from the environment.
   resourcedetection:
     detectors: ["env", "gcp"]

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -8,3 +8,4 @@ opentelemetry-instrumentation-flask==0.45b0
 opentelemetry-instrumentation-requests==0.45b0
 opentelemetry-instrumentation-logging==0.45b0
 python-json-logger==2.0.7
+gunicorn==22.0.0


### PR DESCRIPTION
Changes:

* Use gunicorn
* Manually configure the resource in the app instead of using the OTEL_SERVICE_NAME env var.
* Use the PID as the service.instance.id to avoid duplicate timeseries errors.
* Change the `resource` processor in the collector to provide defaults, and not to override the resource from the application