### PR TITLE
Update tox.ini to not use separate pip steps

### DIFF
--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -13,6 +13,7 @@ types-protobuf==3.20.4.2
 types-requests==2.28.11.2
 types-setuptools==65.5.0.2
 types-urllib3==1.26.25.1
+setuptools==69.5.1
 
 # pinned for snapshot tests. this should be bumped regularly and snapshots updated by running
 # tox -f py311-test -- --snapshot-update

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
+requires =
+  tox>=4
 envlist =
   ; Add the `ci` factor to any env that should be running during CI.
   py3{7,8,9,10,11}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
@@ -35,6 +37,7 @@ dev_deps =
   mypy
   pylint
   pytest
+  setuptools
   syrupy
   types-protobuf
   types-requests
@@ -57,15 +60,17 @@ setenv =
 
 [testenv:py3{7,8,9,10,11}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 deps =
+  ; editable install the package itself
+  -e {toxinidir}/{env:PACKAGE_NAME}
   test: {[constants]base_deps}
   test: {[constants]monorepo_deps}
+  ; test specific deps
   test: pytest
   test: syrupy
 passenv = SKIP_GET_MOCK_SERVER
 changedir = {env:PACKAGE_NAME}
 
 commands_pre =
-  pip install -c {toxinidir}/dev-constraints.txt .
   {toxinidir}/get_mock_server.sh {envbindir}
 
 commands = pytest --junitxml={[constants]test_results_dir}/{envname}/junit.xml {posargs}
@@ -77,13 +82,11 @@ allowlist_externals =
 [testenv:{lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 basepython = {[constants]dev_basepython}
 deps =
+  ; editable install the package itself
+  -e {toxinidir}/{env:PACKAGE_NAME}
   {[constants]dev_deps}
   {[constants]monorepo_deps}
 changedir = {env:PACKAGE_NAME}
-
-commands_pre =
-  pip install -c {toxinidir}/dev-constraints.txt .
-
 commands =
   lint: black . --diff --check
   lint: isort . --diff --check-only


### PR DESCRIPTION
This makes testing a bit faster and allows pip to fully consider all dependencies at once. It also makes tox.ini compatible with [tox-uv](https://github.com/tox-dev/tox-uv) which is handy for speeding up local runs.