### PR TITLE
Run e2e tests on GAE standard

### DIFF
--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -1,0 +1,48 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Build function source zip with vendored wheels of packages in this monorepo
+  - name: python:3.11-slim
+    id: build
+    script: |
+      set -xe
+      apt-get update
+      apt-get install -y zip
+
+      cd e2e-test-server/
+      # package monorepo libraries into wheels in local wheels/ directory
+      pip wheel \
+        --no-deps \
+        --wheel-dir wheels \
+        ../opentelemetry-exporter-gcp-trace/ \
+        ../opentelemetry-resourcedetector-gcp/ \
+        ../opentelemetry-propagator-gcp
+
+      zip -qr appsource.zip .
+
+  # Run the test
+  - name: $_TEST_RUNNER_IMAGE
+    id: run-tests-gae-standard
+    dir: /
+    env: ["PROJECT_ID=$PROJECT_ID"]
+    args:
+      - gae-standard
+      - --runtime=python311
+      - --entrypoint=python main.py
+      - --appsource=/workspace/e2e-test-server/appsource.zip
+
+logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+substitutions:
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1


### PR DESCRIPTION
The build script is copied from Cloud Functions yaml which also builds a source zip with monorepo dependencies packaged in