### PR TITLE
Add links to quickstart and observability overview PyPI README.rst and sphinx docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,13 @@ resource detectors for Google Cloud Platform. Development for these packages
 takes place on `Github
 <https://github.com/GoogleCloudPlatform/opentelemetry-operations-python>`_.
 
+To get started with instrumentation in Google Cloud, see `Generate traces and metrics with
+Python <https://cloud.google.com/stackdriver/docs/instrumentation/setup/python>`_.
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit `Instrumentation and observability
+<https://cloud.google.com/stackdriver/docs/instrumentation/overview>`_.
+
 Installation
 ------------
 

--- a/opentelemetry-exporter-gcp-monitoring/README.rst
+++ b/opentelemetry-exporter-gcp-monitoring/README.rst
@@ -11,6 +11,13 @@ OpenTelemetry Google Cloud Monitoring Exporter
 This library provides support for exporting metrics to Google Cloud
 Monitoring.
 
+To get started with instrumentation in Google Cloud, see `Generate traces and metrics with
+Python <https://cloud.google.com/stackdriver/docs/instrumentation/setup/python>`_.
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit `Instrumentation and observability
+<https://cloud.google.com/stackdriver/docs/instrumentation/overview>`_.
+
 For resource detection and GCP trace context propagation, see
 `opentelemetry-tools-google-cloud
 <https://pypi.org/project/opentelemetry-tools-google-cloud/>`_. For the

--- a/opentelemetry-exporter-gcp-trace/README.rst
+++ b/opentelemetry-exporter-gcp-trace/README.rst
@@ -10,6 +10,13 @@ OpenTelemetry Google Cloud Integration
 
 This library provides support for exporting traces to Google Cloud Trace.
 
+To get started with instrumentation in Google Cloud, see `Generate traces and metrics with
+Python <https://cloud.google.com/stackdriver/docs/instrumentation/setup/python>`_.
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit `Instrumentation and observability
+<https://cloud.google.com/stackdriver/docs/instrumentation/overview>`_.
+
 For resource detection and GCP trace context propagation, see
 `opentelemetry-tools-google-cloud
 <https://pypi.org/project/opentelemetry-tools-google-cloud/>`_. For the

--- a/opentelemetry-propagator-gcp/README.rst
+++ b/opentelemetry-propagator-gcp/README.rst
@@ -11,6 +11,13 @@ OpenTelemetry Google Cloud Propagator
 This library provides support for propagating trace context in the Google
 Cloud ``X-Cloud-Trace-Context`` format.
 
+To get started with instrumentation in Google Cloud, see `Generate traces and metrics with
+Python <https://cloud.google.com/stackdriver/docs/instrumentation/setup/python>`_.
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit `Instrumentation and observability
+<https://cloud.google.com/stackdriver/docs/instrumentation/overview>`_.
+
 Installation
 ------------
 

--- a/opentelemetry-resourcedetector-gcp/README.rst
+++ b/opentelemetry-resourcedetector-gcp/README.rst
@@ -10,6 +10,13 @@ OpenTelemetry Google Cloud Resource Detector
 
 This library provides support for detecting GCP resources like GCE, GKE, etc.
 
+To get started with instrumentation in Google Cloud, see `Generate traces and metrics with
+Python <https://cloud.google.com/stackdriver/docs/instrumentation/setup/python>`_.
+
+To learn more about instrumentation and observability, including opinionated recommendations
+for Google Cloud Observability, visit `Instrumentation and observability
+<https://cloud.google.com/stackdriver/docs/instrumentation/overview>`_.
+
 Installation
 ------------
 


### PR DESCRIPTION
Forgot these in #358. The README.rst files are what appears on PyPI, and the index.rst is for https://google-cloud-opentelemetry.readthedocs.io/