### PR TITLE
Use a shorter timeout for the metadata endpoint

### DIFF
--- a/opentelemetry-resourcedetector-gcp/CHANGELOG.md
+++ b/opentelemetry-resourcedetector-gcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+
+- Use a shorter connection timeout for reading metadata
+  ([#362](https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/362))
+
 ## Version 1.7.0a0
 
 Released 2024-08-27

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_metadata.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_metadata.py
@@ -25,7 +25,8 @@ _GCP_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/"
 _INSTANCE = "instance"
 _RECURSIVE_PARAMS = {"recursive": "true"}
 _GCP_METADATA_URL_HEADER = {"Metadata-Flavor": "Google"}
-_TIMEOUT_SEC = 5
+# Use a shorter timeout for connection so we won't block much if it's unreachable
+_TIMEOUT = (2, 5)
 
 _logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ def get_metadata() -> Metadata:
             f"{_GCP_METADATA_URL}",
             params=_RECURSIVE_PARAMS,
             headers=_GCP_METADATA_URL_HEADER,
-            timeout=_TIMEOUT_SEC,
+            timeout=_TIMEOUT,
         )
         res.raise_for_status()
         all_metadata = res.json()
@@ -84,7 +85,7 @@ def is_available() -> bool:
         requests.get(
             f"{_GCP_METADATA_URL}{_INSTANCE}/",
             headers=_GCP_METADATA_URL_HEADER,
-            timeout=_TIMEOUT_SEC,
+            timeout=_TIMEOUT,
         ).raise_for_status()
     except requests.RequestException:
         _logger.debug(


### PR DESCRIPTION
Use a shorter timeout of 2 seconds for the connection before the 5 seconds read one to avoid blocking too much if the metadata server is not available.

This makes the code behave more similar to the go one: https://github.com/googleapis/google-cloud-go/blob/main/compute/metadata/metadata.go#L65