### PR TITLE
Update instrumentation sample to use exponential histograms

### DIFF
--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     ports:
       - 8080
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.92.0
+    image: otel/opentelemetry-collector-contrib:0.115.1
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
       - logs:/var/log:ro

--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=otel-quickstart-python
       - OTEL_METRIC_EXPORT_INTERVAL=5000
+      - OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=base2_exponential_bucket_histogram
     volumes:
       - logs:/var/log:rw
     depends_on:

--- a/samples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/samples/instrumentation-quickstart/otel-collector-config.yaml
@@ -111,6 +111,14 @@ processors:
     detectors: ["env", "gcp"]
 
 service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
   pipelines:
     traces:
       receivers: ["otlp"]

--- a/samples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/samples/instrumentation-quickstart/otel-collector-config.yaml
@@ -85,12 +85,12 @@ receivers:
 exporters:
   # Export logs and traces using the standard googelcloud exporter
   googlecloud:
-    project: $GOOGLE_CLOUD_PROJECT
+    project: ${GOOGLE_CLOUD_PROJECT}
     log:
       default_log_name: "opentelemetry.io/collector-exported-log"
   # Export metrics to Google Managed service for Prometheus
   googlemanagedprometheus:
-    project: $GOOGLE_CLOUD_PROJECT
+    project: ${GOOGLE_CLOUD_PROJECT}
 
 processors:
   # Batch telemetry together to more efficiently send to GCP

--- a/samples/instrumentation-quickstart/requirements.txt
+++ b/samples/instrumentation-quickstart/requirements.txt
@@ -1,11 +1,11 @@
 # Dependencies require for the instrumentation sample
-flask==3.0.2
-requests==2.31.0
-opentelemetry-api==1.24.0
-opentelemetry-sdk==1.24.0
-opentelemetry-exporter-otlp-proto-http==1.24.0
-opentelemetry-instrumentation-flask==0.45b0
-opentelemetry-instrumentation-requests==0.45b0
-opentelemetry-instrumentation-logging==0.45b0
-python-json-logger==2.0.7
-gunicorn==22.0.0
+flask==3.1.0
+requests==2.32.3
+opentelemetry-api==1.29.0
+opentelemetry-sdk==1.29.0
+opentelemetry-exporter-otlp-proto-http==1.29.0
+opentelemetry-instrumentation-flask==0.50b0
+opentelemetry-instrumentation-requests==0.50b0
+opentelemetry-instrumentation-logging==0.50b0
+python-json-logger==3.2.0
+gunicorn==23.0.0


### PR DESCRIPTION
I'm trying to debug a customer issue with the python SDK + GMP exporter with exponential histograms, so i'm updating the sample to use exponential histograms.

I verified that exponential histogram  can be queried using both MQL and promql (using histogram_quantile).