### PR TITLE
Fix creation of resources in _detector

### DIFF
--- a/e2e-test-server/e2e_test_server/scenarios.py
+++ b/e2e-test-server/e2e_test_server/scenarios.py
@@ -29,6 +29,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind, Tracer, format_trace_id
+from opentelemetry.sdk.resources import get_aggregated_resources
 from pydantic import BaseModel
 
 from .constants import INSTRUMENTING_MODULE_NAME, PROJECT_ID, TEST_ID, TRACE_ID
@@ -59,9 +60,7 @@ def _tracer_setup(
     spans created during the test after.
     """
 
-    tracer_provider = TracerProvider(
-        sampler=ALWAYS_ON, **tracer_provider_config
-    )
+    tracer_provider = TracerProvider(sampler=ALWAYS_ON, **tracer_provider_config)
     tracer_provider.add_span_processor(
         BatchSpanProcessor(
             CloudTraceSpanExporter(project_id=PROJECT_ID, **exporter_config)
@@ -139,9 +138,9 @@ def detect_resource(request: Request) -> Response:
     """Create a trace with GCP resource detector"""
     with _tracer_setup(
         tracer_provider_config={
-            "resource": GoogleCloudResourceDetector(
-                raise_on_error=True
-            ).detect()
+            "resource": get_aggregated_resources(
+                [GoogleCloudResourceDetector(raise_on_error=True)]
+            )
         },
         exporter_config={"resource_regex": r".*"},
     ) as tracer:

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_detector.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/_detector.py
@@ -129,7 +129,7 @@ def _gae_resource() -> Resource:
 
 
 def _make_resource(attrs: Mapping[str, AttributeValue]) -> Resource:
-    return Resource.create(
+    return Resource(
         {
             ResourceAttributes.CLOUD_PROVIDER: "gcp",
             ResourceAttributes.CLOUD_ACCOUNT_ID: _metadata.get_metadata()[

--- a/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
+++ b/opentelemetry-resourcedetector-gcp/tests/__snapshots__/test_detector.ambr
@@ -7,10 +7,6 @@
     'faas.instance': '0087244a',
     'faas.name': 'fake-service',
     'faas.version': 'fake-revision',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---
 # name: test_detects_cloud_run
@@ -22,10 +18,6 @@
     'faas.instance': '0087244a',
     'faas.name': 'fake-service',
     'faas.version': 'fake-revision',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---
 # name: test_detects_empty_as_fallback
@@ -46,10 +38,6 @@
     'faas.instance': 'fake-instance',
     'faas.name': 'fake-service',
     'faas.version': 'fake-version',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---
 # name: test_detects_gae_standard
@@ -62,10 +50,6 @@
     'faas.instance': 'fake-instance',
     'faas.name': 'fake-service',
     'faas.version': 'fake-version',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---
 # name: test_detects_gce
@@ -78,10 +62,6 @@
     'host.id': '0087244a',
     'host.name': 'fakeName',
     'host.type': 'fakeMachineType',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---
 # name: test_detects_gke[regional]
@@ -92,10 +72,6 @@
     'cloud.region': 'us-east4',
     'host.id': '12345',
     'k8s.cluster.name': 'fakeClusterName',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---
 # name: test_detects_gke[zonal]
@@ -106,9 +82,5 @@
     'cloud.provider': 'gcp',
     'host.id': '12345',
     'k8s.cluster.name': 'fakeClusterName',
-    'service.name': 'unknown_service',
-    'telemetry.sdk.language': 'python',
-    'telemetry.sdk.name': 'opentelemetry',
-    'telemetry.sdk.version': '1.20.0',
   })
 # ---


### PR DESCRIPTION
We should create a Resource instance and not use Resource.create because if we set OTEL_EXPERIMENTAL_RESOURCE_DETECTORS we will go into an infinite loop trying to load and instantiate all the resources detectors.

See [Resource.create implementation](https://github.com/open-telemetry/opentelemetry-python/blob/b48223561acfdffd1411ed7d015ddabe6f6eb801/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py#L172)

Fix #363