### PR TITLE
Fix CI and test with python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         py:
@@ -19,6 +19,7 @@ jobs:
           - { version: "3.10", tox: "310" }
           - { version: "3.11", tox: "311" }
           - { version: "3.12", tox: "312" }
+          - { version: "3.13", tox: "313" }
     env:
       run-matrix-combo: ${{ matrix.py.version }}
 
@@ -44,7 +45,7 @@ jobs:
           -f py${{ matrix.py.tox }}-ci
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [lint-ci, docs-ci, mypy-ci]

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 python_requires = >=3.7

--- a/opentelemetry-exporter-gcp-trace/setup.cfg
+++ b/opentelemetry-exporter-gcp-trace/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 python_requires = >=3.7

--- a/opentelemetry-propagator-gcp/setup.cfg
+++ b/opentelemetry-propagator-gcp/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 python_requires = >=3.7

--- a/opentelemetry-resourcedetector-gcp/setup.cfg
+++ b/opentelemetry-resourcedetector-gcp/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 python_requires = >=3.7

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ requires =
   tox>=4
 envlist =
   ; Add the `ci` factor to any env that should be running during CI.
-  py3{7,8,9,10,11,12}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
+  py3{7,8,9,10,11,12,13}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   {lint,mypy}-ci-{cloudtrace,cloudmonitoring,propagator,resourcedetector}
   docs-ci
 
@@ -58,7 +58,7 @@ setenv =
   propagator: PACKAGE_NAME = opentelemetry-propagator-gcp
   resourcedetector: PACKAGE_NAME = opentelemetry-resourcedetector-gcp
 
-[testenv:py3{7,8,9,10,11,12}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
+[testenv:py3{7,8,9,10,11,12,13}-ci-test-{cloudtrace,cloudmonitoring,propagator,resourcedetector}]
 deps =
   ; editable install the package itself
   -e {toxinidir}/{env:PACKAGE_NAME}


### PR DESCRIPTION
This fixes failing CI checks.

- Pinning ubuntu to 22.04 so that python 3.7 is still available (https://github.com/actions/setup-python/issues/962). We should eventually drop 3.7 (https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/367), which is EOL.
- Start testing python 3.13 while we're at it