### PR TITLE
Setup OTel logs and events in quickstart

### DIFF
--- a/samples/instrumentation-quickstart/setup_opentelemetry.py
+++ b/samples/instrumentation-quickstart/setup_opentelemetry.py
@@ -14,33 +14,44 @@
 
 import os
 
-from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, SERVICE_NAME, Resource
-
-from opentelemetry import trace
+from opentelemetry import _logs as logs
+from opentelemetry import _events as events
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._events import EventLoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from opentelemetry import metrics
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
 # [START opentelemetry_instrumentation_setup_opentelemetry]
-resource = Resource.create(attributes={
-    # Use the PID as the service.instance.id to avoid duplicate timeseries
-    # from different Gunicorn worker processes.
-    SERVICE_INSTANCE_ID: f"worker-{os.getpid()}",
-})
-
-traceProvider = TracerProvider(resource=resource)
-processor = BatchSpanProcessor(OTLPSpanExporter())
-traceProvider.add_span_processor(processor)
-trace.set_tracer_provider(traceProvider)
-
-reader = PeriodicExportingMetricReader(
-    OTLPMetricExporter()
+resource = Resource.create(
+    attributes={
+        # Use the PID as the service.instance.id to avoid duplicate timeseries
+        # from different Gunicorn worker processes.
+        SERVICE_INSTANCE_ID: f"worker-{os.getpid()}",
+    }
 )
-meterProvider = MeterProvider(metric_readers=[reader], resource=resource)
-metrics.set_meter_provider(meterProvider)
+
+# Set up OpenTelemetry Python SDK
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
+
+logger_provider = LoggerProvider(resource=resource)
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter()))
+logs.set_logger_provider(logger_provider)
+
+event_logger_provider = EventLoggerProvider(logger_provider)
+events.set_event_logger_provider(event_logger_provider)
+
+reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+meter_provider = MeterProvider(metric_readers=[reader], resource=resource)
+metrics.set_meter_provider(meter_provider)
 # [END opentelemetry_instrumentation_setup_opentelemetry]


### PR DESCRIPTION
This is not used in the quickstart code itself, but GenAI instrumentations do use it. We want users to use this proper setup code.