### PR TITLE
Add microsecond precision to quickstart logs

### DIFF
--- a/samples/instrumentation-quickstart/app.py
+++ b/samples/instrumentation-quickstart/app.py
@@ -58,6 +58,7 @@ def multi():
 def single():
     """Handle an http request by sleeping for 100-200 ms, and write the number of seconds slept as the response."""
     duration = uniform(0.1, 0.2)
+    logger.info("handle /single request", extra={"duration": duration})
     time.sleep(duration)
     return f"slept {duration} seconds"
 


### PR DESCRIPTION
The python logging `datefmt` parameter does not support sub-second precision because it calls `time.strftime` ([docs](https://docs.python.org/3/library/time.html#:~:text=The%20%25f%20format%20directive%20only%20applies%20to%20strptime()%2C%20not%20to%20strftime().%20However%2C%20see%20also%20datetime.datetime.strptime()%20and%20datetime.datetime.strftime()%20where%20the%20%25f%20format%20directive%20applies%20to%20microseconds.)).

Instead of being limited by `datefmt`, I override the `formatTime()` function to get microsecond precision.
<img width="1626" alt="Screenshot 2025-04-22 at 4 07 10 PM" src="https://github.com/user-attachments/assets/5b003bff-8007-4181-a3c4-90227255715c" />
