### PR TITLE
Add support for exponential histograms

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -137,7 +137,9 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         self._metric_descriptors: Dict[str, MetricDescriptor] = {}
         self.unique_identifier = None
         if add_unique_identifier:
-            self.unique_identifier = "{:08x}".format(random.randint(0, 16**8))
+            self.unique_identifier = "{:08x}".format(
+                random.randint(0, 16**8)
+            )
 
         (
             self._exporter_start_time_seconds,
@@ -405,9 +407,9 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                             ).items()
                         }
                         if self.unique_identifier:
-                            labels[UNIQUE_IDENTIFIER_KEY] = (
-                                self.unique_identifier
-                            )
+                            labels[
+                                UNIQUE_IDENTIFIER_KEY
+                            ] = self.unique_identifier
                         point = self._to_point(
                             descriptor.metric_kind, data_point
                         )

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -286,9 +286,6 @@ class CloudMonitoringMetricsExporter(MetricExporter):
             )
         elif isinstance(data_point, ExponentialHistogramDataPoint):
             # Adapted from https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v1.8.0/exporter/collector/metrics.go#L582
-            mean = (
-                data_point.sum / data_point.count if data_point.count else 0.0
-            )
 
             # Calculate underflow bucket (zero count + negative buckets)
             underflow = data_point.zero_count
@@ -325,6 +322,9 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                     )
                 )
 
+            mean = (
+                data_point.sum / data_point.count if data_point.count else 0.0
+            )
             point_value = TypedValue(
                 distribution_value=Distribution(
                     count=data_point.count,

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import math
 import random
 from dataclasses import replace
 from time import time_ns
@@ -136,9 +137,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         self._metric_descriptors: Dict[str, MetricDescriptor] = {}
         self.unique_identifier = None
         if add_unique_identifier:
-            self.unique_identifier = "{:08x}".format(
-                random.randint(0, 16**8)
-            )
+            self.unique_identifier = "{:08x}".format(random.randint(0, 16**8))
 
         (
             self._exporter_start_time_seconds,
@@ -212,11 +211,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         elif isinstance(data, Histogram):
             descriptor.metric_kind = MetricDescriptor.MetricKind.CUMULATIVE
         elif isinstance(data, ExponentialHistogram):
-            logger.warning(
-                "Unsupported metric data type %s, ignoring it",
-                type(data).__name__,
-            )
-            return None
+            descriptor.metric_kind = MetricDescriptor.MetricKind.CUMULATIVE
         else:
             # Exhaustive check
             _: NoReturn = data
@@ -234,6 +229,8 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                 else MetricDescriptor.ValueType.DOUBLE
             )
         elif isinstance(first_point, HistogramDataPoint):
+            descriptor.value_type = MetricDescriptor.ValueType.DISTRIBUTION
+        elif isinstance(first_point, ExponentialHistogramDataPoint):
             descriptor.value_type = MetricDescriptor.ValueType.DISTRIBUTION
         elif first_point is None:
             pass
@@ -265,7 +262,9 @@ class CloudMonitoringMetricsExporter(MetricExporter):
     @staticmethod
     def _to_point(
         kind: "MetricDescriptor.MetricKind.V",
-        data_point: Union[NumberDataPoint, HistogramDataPoint],
+        data_point: Union[
+            NumberDataPoint, HistogramDataPoint, ExponentialHistogramDataPoint
+        ],
     ) -> Point:
         if isinstance(data_point, HistogramDataPoint):
             mean = (
@@ -281,6 +280,55 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                             bounds=data_point.explicit_bounds,
                         )
                     ),
+                )
+            )
+        elif isinstance(data_point, ExponentialHistogramDataPoint):
+            # Adapted from https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v1.8.0/exporter/collector/metrics.go#L582
+            mean = (
+                data_point.sum / data_point.count if data_point.count else 0.0
+            )
+
+            # Calculate underflow bucket (zero count + negative buckets)
+            underflow = data_point.zero_count
+            if data_point.negative.bucket_counts:
+                underflow += sum(data_point.negative.bucket_counts)
+
+            # Create bucket counts array: [underflow, positive_buckets..., overflow=0]
+            bucket_counts = [underflow]
+            if data_point.positive.bucket_counts:
+                bucket_counts.extend(data_point.positive.bucket_counts)
+            bucket_counts.append(0)  # overflow bucket is always empty
+
+            # Determine bucket options
+            if not data_point.positive.bucket_counts:
+                # If no positive buckets, use explicit buckets with bounds=[0]
+                bucket_options = Distribution.BucketOptions(
+                    explicit_buckets=Distribution.BucketOptions.Explicit(
+                        bounds=[0.0],
+                    )
+                )
+            else:
+                # Use exponential bucket options
+                # growth_factor = 2^(2^(-scale))
+                growth_factor = math.pow(2, math.pow(2, -data_point.scale))
+                # scale = growth_factor^(positive_bucket_offset)
+                scale = math.pow(growth_factor, data_point.positive.offset)
+                num_finite_buckets = len(bucket_counts) - 2
+
+                bucket_options = Distribution.BucketOptions(
+                    exponential_buckets=Distribution.BucketOptions.Exponential(
+                        num_finite_buckets=num_finite_buckets,
+                        growth_factor=growth_factor,
+                        scale=scale,
+                    )
+                )
+
+            point_value = TypedValue(
+                distribution_value=Distribution(
+                    count=data_point.count,
+                    mean=mean,
+                    bucket_counts=bucket_counts,
+                    bucket_options=bucket_options,
                 )
             )
         else:
@@ -350,10 +398,6 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                         continue
 
                     for data_point in metric.data.data_points:
-                        if isinstance(
-                            data_point, ExponentialHistogramDataPoint
-                        ):
-                            continue
                         labels = {
                             _normalize_label_key(key): str(value)
                             for key, value in (
@@ -361,9 +405,9 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                             ).items()
                         }
                         if self.unique_identifier:
-                            labels[
-                                UNIQUE_IDENTIFIER_KEY
-                            ] = self.unique_identifier
+                            labels[UNIQUE_IDENTIFIER_KEY] = (
+                                self.unique_identifier
+                            )
                         point = self._to_point(
                             descriptor.metric_kind, data_point
                         )

--- a/opentelemetry-exporter-gcp-monitoring/tests/__snapshots__/test_cloud_monitoring/test_exponential_histogram.json
+++ b/opentelemetry-exporter-gcp-monitoring/tests/__snapshots__/test_cloud_monitoring/test_exponential_histogram.json
@@ -1,0 +1,238 @@
+{
+  "/google.monitoring.v3.MetricService/CreateMetricDescriptor": [
+    {
+      "metricDescriptor": {
+        "description": "foo",
+        "displayName": "myexponentialhistogram",
+        "labels": [
+          {
+            "key": "string"
+          },
+          {
+            "key": "int"
+          },
+          {
+            "key": "float"
+          }
+        ],
+        "metricKind": "CUMULATIVE",
+        "type": "workload.googleapis.com/myexponentialhistogram",
+        "unit": "{myunit}",
+        "valueType": "DISTRIBUTION"
+      },
+      "name": "projects/fakeproject"
+    }
+  ],
+  "/google.monitoring.v3.MetricService/CreateTimeSeries": [
+    {
+      "name": "projects/fakeproject",
+      "timeSeries": [
+        {
+          "metric": {
+            "labels": {
+              "float": "123.4",
+              "int": "123",
+              "string": "string"
+            },
+            "type": "workload.googleapis.com/myexponentialhistogram"
+          },
+          "metricKind": "CUMULATIVE",
+          "points": [
+            {
+              "interval": {
+                "endTime": "str",
+                "startTime": "str"
+              },
+              "value": {
+                "distributionValue": {
+                  "bucketCounts": [
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0"
+                  ],
+                  "bucketOptions": {
+                    "exponentialBuckets": {
+                      "growthFactor": 1.0218971486541166,
+                      "numFiniteBuckets": 160,
+                      "scale": 24.67537320652687
+                    }
+                  },
+                  "count": "7",
+                  "mean": 128.57142857142858
+                }
+              }
+            }
+          ],
+          "resource": {
+            "labels": {
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
+            },
+            "type": "generic_node"
+          },
+          "unit": "{myunit}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fix for https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/357. Based on the Go / TS implementations, https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/d6795b491c748855e4a4d6eec07ae2cb44a78da1/exporter/metric/metric.go#L723.

I've tested this on a small app, and it seems to work fine.