### PR TITLE
Handle AlreadyExists error in metric descriptor creation

### DIFF
--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -20,6 +20,7 @@ from time import time_ns
 from typing import Dict, List, NoReturn, Optional, Set, Union
 
 import google.auth
+from google.api_core.exceptions import AlreadyExists
 from google.api.distribution_pb2 import (  # pylint: disable=no-name-in-module
     Distribution,
 )
@@ -250,6 +251,15 @@ class CloudMonitoringMetricsExporter(MetricExporter):
                     name=self.project_name, metric_descriptor=descriptor
                 )
             )
+        except AlreadyExists:
+            # Metric descriptor already exists, cache and return our descriptor.
+            # GCP will update the descriptor on metric export if needed.
+            logger.debug(
+                "Metric descriptor %s already exists, using local descriptor",
+                descriptor_type,
+            )
+            self._metric_descriptors[descriptor_type] = descriptor
+            return descriptor
         # pylint: disable=broad-except
         except Exception as ex:
             logger.error(


### PR DESCRIPTION
When creating a metric descriptor, catch the AlreadyExists (409) error
and return the local descriptor instead of failing. GCP will update
the descriptor on metric export if needed.

In https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/af5d0725de16c84417f993a21fea3f346e0780c7/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py#L398-L400, if we get metric descriptor already exists exception ( as below ) , the metric emission is skipped.


```
Failed to create metric descriptor labels {
  key: "path"
}
labels {
  key: "opentelemetry_id"
}
....
    raise exceptions.from_grpc_error(exc) from exc
google.api_core.exceptions.AlreadyExists: 409 Errors during metric descriptor creation: {(metric: custom.googleapis.com/app/fastapi/request_count, error: The metric already exists.)}.
```

