### PR TITLE
docs(samples): bump loadgen Go version to 1.24 for compatibility

### DIFF
--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       # Collector prometheus port. The metrics are checked in tests
       - 8888
   loadgen:
-    image: golang:1.21
+    image: golang:1.24-bookworm
     command:
       [
         "go",


### PR DESCRIPTION
The current Go version (1.21) is too old for the `hey` tool, causing the "instrumentation-quickstart" sample to fail.