### PR TITLE
release pr/1.12.0

### DIFF
--- a/opentelemetry-exporter-gcp-logging/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-logging/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.12.0a0
+
+Released 2026-04-28
+
 ## Version 1.11.0a0
 
 Released 2025-11-04

--- a/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/version.py
+++ b/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0a0"
+__version__ = "1.13.0.dev0"

--- a/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/version.py
+++ b/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0.dev0"
+__version__ = "1.12.0a0"

--- a/opentelemetry-exporter-gcp-monitoring/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-monitoring/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.12.0a0
+
+Released 2026-04-28
+
 ## Version 1.11.0a0
 
 Released 2025-11-04

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0a0"
+__version__ = "1.13.0.dev0"

--- a/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
+++ b/opentelemetry-exporter-gcp-monitoring/src/opentelemetry/exporter/cloud_monitoring/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0.dev0"
+__version__ = "1.12.0a0"

--- a/opentelemetry-exporter-gcp-trace/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-trace/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.12.0
+
+Released 2026-04-28
+
 ## Version 1.11.0
 
 Released 2025-11-04

--- a/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
+++ b/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0.dev0"
+__version__ = "1.12.0"

--- a/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
+++ b/opentelemetry-exporter-gcp-trace/src/opentelemetry/exporter/cloud_trace/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0"
+__version__ = "1.13.0.dev0"

--- a/opentelemetry-propagator-gcp/CHANGELOG.md
+++ b/opentelemetry-propagator-gcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.12.0
+
+Released 2026-04-28
+
 ## Version 1.11.0
 
 Released 2025-11-04

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0.dev0"
+__version__ = "1.12.0"

--- a/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
+++ b/opentelemetry-propagator-gcp/src/opentelemetry/propagators/cloud_trace_propagator/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0"
+__version__ = "1.13.0.dev0"

--- a/opentelemetry-resourcedetector-gcp/CHANGELOG.md
+++ b/opentelemetry-resourcedetector-gcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 1.12.0a0
+
+Released 2026-04-28
+
 ## Version 1.11.0a0
 
 Released 2025-11-04

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0a0"
+__version__ = "1.13.0.dev0"

--- a/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
+++ b/opentelemetry-resourcedetector-gcp/src/opentelemetry/resourcedetector/gcp_resource_detector/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.0.dev0"
+__version__ = "1.12.0a0"


### PR DESCRIPTION
- **Release 1.12.0 (Part 1/2) release commit**
- **Release 1.12.0 (Part 2/2) bump version to 1.13.0.dev0**

Created following https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/main/docs/releasing.md, review individual commits.
