### PR TITLE
Add force_flush method to CloudLoggingExporter

### DIFF
--- a/opentelemetry-exporter-gcp-logging/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-logging/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `force_flush` method to `CloudLoggingExporter` (#559)
+
 ## Version 1.13.0a0
 
 Released 2026-07-29

--- a/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/__init__.py
+++ b/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/__init__.py
@@ -81,6 +81,8 @@ PROJECT_ID_ATTRIBUTE_KEY = "gcp.project_id"
 _OTEL_SDK_VERSION = opentelemetry_sdk_version.__version__
 _USER_AGENT = f"opentelemetry-python {_OTEL_SDK_VERSION}; google-cloud-logging-exporter {__version__}"
 
+logger = logging.getLogger(__name__)
+
 # Set user-agent metadata, see https://github.com/grpc/grpc/issues/23644 and default options
 # from
 # https://github.com/googleapis/python-logging/blob/5309478c054d0f2b9301817fd835f2098f51dc3a/google/cloud/logging_v2/services/logging_service_v2/transports/grpc.py#L179-L182
@@ -473,6 +475,14 @@ class CloudLoggingExporter(LogRecordExporter):
                 logging.error(
                     "Error while writing to Cloud Logging", exc_info=ex
                 )
+
+    def force_flush(self, timeout_millis: float = 30_000) -> bool:
+        """Flushes any buffered logs.
+
+        For CloudLoggingExporter, this is a no-op as logs are exported synchronously.
+        """
+        logger.info("force_flush does nothing for CloudLoggingExporter")
+        return True
 
     def shutdown(self):
         pass

--- a/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/__init__.py
+++ b/opentelemetry-exporter-gcp-logging/src/opentelemetry/exporter/cloud_logging/__init__.py
@@ -476,12 +476,13 @@ class CloudLoggingExporter(LogRecordExporter):
                     "Error while writing to Cloud Logging", exc_info=ex
                 )
 
+    # pylint: disable=unused-argument,no-self-use
     def force_flush(self, timeout_millis: float = 30_000) -> bool:
         """Flushes any buffered logs.
 
         For CloudLoggingExporter, this is a no-op as logs are exported synchronously.
         """
-        logger.info("force_flush does nothing for CloudLoggingExporter")
+        logger.debug("force_flush does nothing for CloudLoggingExporter")
         return True
 
     def shutdown(self):

--- a/opentelemetry-exporter-gcp-logging/tests/test_cloud_logging.py
+++ b/opentelemetry-exporter-gcp-logging/tests/test_cloud_logging.py
@@ -26,6 +26,7 @@ tox -e py310-ci-test-cloudlogging -- --snapshot-update
 Be sure to review the changes.
 """
 
+import logging
 import re
 from io import StringIO
 from textwrap import dedent
@@ -452,3 +453,15 @@ def test_deprecation_warning():
     buf = StringIO()
     with pytest.deprecated_call():
         CloudLoggingExporter(project_id=PROJECT_ID, structured_json_file=buf)
+
+
+def test_force_flush(caplog):
+    buf = StringIO()
+    with pytest.deprecated_call():
+        exporter = CloudLoggingExporter(
+            project_id=PROJECT_ID, structured_json_file=buf
+        )
+    with caplog.at_level(logging.INFO):
+        assert exporter.force_flush() is True
+        assert exporter.force_flush(timeout_millis=1000) is True
+    assert "force_flush does nothing for CloudLoggingExporter" in caplog.text

--- a/opentelemetry-exporter-gcp-logging/tests/test_cloud_logging.py
+++ b/opentelemetry-exporter-gcp-logging/tests/test_cloud_logging.py
@@ -461,7 +461,7 @@ def test_force_flush(caplog):
         exporter = CloudLoggingExporter(
             project_id=PROJECT_ID, structured_json_file=buf
         )
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         assert exporter.force_flush() is True
         assert exporter.force_flush(timeout_millis=1000) is True
     assert "force_flush does nothing for CloudLoggingExporter" in caplog.text


### PR DESCRIPTION
v1.44 of otel sdk breaks the exporter because it requires a force_flush method on logging exporters... This PR fixes it