### PR TITLE
Add deprecation warnings to exporter READMEs and update resource detector to be <1.15

### DIFF
--- a/opentelemetry-exporter-gcp-logging/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-logging/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add deprecation warning to README
+- Update `opentelemetry-resourcedetector-gcp` dependency to `< 1.15`
 - Add `force_flush` method to `CloudLoggingExporter` (#559)
 
 ## Version 1.13.0a0

--- a/opentelemetry-exporter-gcp-logging/README.rst
+++ b/opentelemetry-exporter-gcp-logging/README.rst
@@ -8,6 +8,14 @@ OpenTelemetry Google Cloud Logging Exporter
     :target: https://google-cloud-opentelemetry.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. warning::
+
+    **This exporter is deprecated.**
+
+    Google Cloud supports native OpenTelemetry Protocol (OTLP) ingestion for Cloud Trace, Cloud Monitoring, and Cloud Logging via the `Telemetry API <https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/overview>`_.
+
+    Please refer to the `Migration Guide <https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/main/MIGRATION.md>`_ for detailed instructions on migrating your application to standard OpenTelemetry OTLP exporters.
+
 This library provides support for exporting logs to Google Cloud
 Logging.
 

--- a/opentelemetry-exporter-gcp-logging/setup.cfg
+++ b/opentelemetry-exporter-gcp-logging/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     opentelemetry-sdk >= 1.39.0
     opentelemetry-api >= 1.39.0
 
-    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, == 1.*
+    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, < 1.15
     typing-extensions
 
 

--- a/opentelemetry-exporter-gcp-monitoring/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-monitoring/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add deprecation warning to README
+- Update `opentelemetry-resourcedetector-gcp` dependency to `< 1.15`
+
 ## Version 1.13.0a0
 
 Released 2026-07-29

--- a/opentelemetry-exporter-gcp-monitoring/README.rst
+++ b/opentelemetry-exporter-gcp-monitoring/README.rst
@@ -8,6 +8,14 @@ OpenTelemetry Google Cloud Monitoring Exporter
     :target: https://google-cloud-opentelemetry.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. warning::
+
+    **This exporter is deprecated.**
+
+    Google Cloud supports native OpenTelemetry Protocol (OTLP) ingestion for Cloud Trace, Cloud Monitoring, and Cloud Logging via the `Telemetry API <https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/overview>`_.
+
+    Please refer to the `Migration Guide <https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/main/MIGRATION.md>`_ for detailed instructions on migrating your application to standard OpenTelemetry OTLP exporters.
+
 This library provides support for exporting metrics to Google Cloud
 Monitoring.
 

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -1,4 +1,4 @@
-    [metadata]
+[metadata]
 name = opentelemetry-exporter-gcp-monitoring
 description = Google Cloud Monitoring exporter for OpenTelemetry
 long_description = file: README.rst

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     google-cloud-monitoring ~= 2.0
     opentelemetry-api ~= 1.30
     opentelemetry-sdk ~= 1.30
-    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, == 1.*
+    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, < 1.15 1.15
     typing-extensions
 
 

--- a/opentelemetry-exporter-gcp-monitoring/setup.cfg
+++ b/opentelemetry-exporter-gcp-monitoring/setup.cfg
@@ -1,4 +1,4 @@
-[metadata]
+    [metadata]
 name = opentelemetry-exporter-gcp-monitoring
 description = Google Cloud Monitoring exporter for OpenTelemetry
 long_description = file: README.rst
@@ -29,7 +29,7 @@ install_requires =
     google-cloud-monitoring ~= 2.0
     opentelemetry-api ~= 1.30
     opentelemetry-sdk ~= 1.30
-    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, < 1.15 1.15
+    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, < 1.15
     typing-extensions
 
 

--- a/opentelemetry-exporter-gcp-trace/CHANGELOG.md
+++ b/opentelemetry-exporter-gcp-trace/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add deprecation warning to README
+- Update `opentelemetry-resourcedetector-gcp` dependency to `< 1.15`
+
 ## Version 1.13.0
 
 Released 2026-07-29

--- a/opentelemetry-exporter-gcp-trace/README.rst
+++ b/opentelemetry-exporter-gcp-trace/README.rst
@@ -8,6 +8,14 @@ OpenTelemetry Google Cloud Integration
     :target: https://google-cloud-opentelemetry.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. warning::
+
+    **This exporter is deprecated.**
+
+    Google Cloud supports native OpenTelemetry Protocol (OTLP) ingestion for Cloud Trace, Cloud Monitoring, and Cloud Logging via the `Telemetry API <https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/overview>`_.
+
+    Please refer to the `Migration Guide <https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/main/MIGRATION.md>`_ for detailed instructions on migrating your application to standard OpenTelemetry OTLP exporters.
+
 This library provides support for exporting traces to Google Cloud Trace.
 
 To get started with instrumentation in Google Cloud, see `Generate traces and metrics with

--- a/opentelemetry-exporter-gcp-trace/setup.cfg
+++ b/opentelemetry-exporter-gcp-trace/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     google-cloud-trace ~= 1.1
     opentelemetry-api ~= 1.30
     opentelemetry-sdk ~= 1.30
-    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, == 1.*
+    opentelemetry-resourcedetector-gcp >= 1.5.0dev0, < 1.15
     typing-extensions
 
 


### PR DESCRIPTION
Add deprecation warnings to READMEs and update resource detector to be <1.15 as we may make changes to it which break the exporters